### PR TITLE
退避した旧フロントエンド実装の deps を更新しない

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
   "prConcurrentLimit": 0,
   "labels": ["dependencies"],
   "postUpdateOptions": ["gomodUpdateImportPaths", "gomodTidy"],
+  "ignorePaths": ["frontend-old/**"],
   "packageRules": [
     {
       "description": "Upgrade go indirect dependencies",


### PR DESCRIPTION
テストももう走っていないので更新され続けると壊れると思われる