### PR TITLE
chore: manage protoc as go tools

### DIFF
--- a/backend/buf.gen.yaml
+++ b/backend/buf.gen.yaml
@@ -5,9 +5,9 @@ clean: true
 inputs:
   - directory: ../proto
 plugins:
-  - remote: buf.build/protocolbuffers/go
+  - local: ["go", "run", "google.golang.org/protobuf/cmd/protoc-gen-go"]
     out: pkg/proto
     opt: paths=source_relative
-  - remote: buf.build/connectrpc/go
+  - local: ["go", "run", "connectrpc.com/connect/cmd/protoc-gen-connect-go"]
     out: pkg/proto
     opt: paths=source_relative

--- a/backend/tools.go
+++ b/backend/tools.go
@@ -4,4 +4,6 @@ package main
 import (
 	_ "github.com/bufbuild/buf/cmd/buf"
 	_ "github.com/sqldef/sqldef/cmd/psqldef"
+	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
+	_ "connectrpc.com/connect/cmd/protoc-gen-connect-go"
 )


### PR DESCRIPTION
protoc のバージョンがサイレントに変わって CI が落ちるなどの問題がある。
buf remote plugin のバージョンを指定するという方法もあるが，Renovate で直接は管理できない(Custom Manager が必要)なのであまりやりたくない。
他のツールと同様に tools.go の管理下に置くことにする