### PR TITLE
feat: implement discord auth

### DIFF
--- a/backend/cmd/scoreserver/config.go
+++ b/backend/cmd/scoreserver/config.go
@@ -83,7 +83,21 @@ func newAdminConfig(opts *CLIOption) (*config.AdminAPI, error) {
 }
 
 func newContestantConfig(opts *CLIOption) (*config.ContestantAPI, error) {
+	discordClientID := os.Getenv("DISCORD_CLIENT_ID")
+	if discordClientID == "" {
+		return nil, errors.New("DISCORD_CLIENT_ID is not set")
+	}
+	discordClientSecret := os.Getenv("DISCORD_CLIENT_SECRET")
+	if discordClientSecret == "" {
+		return nil, errors.New("DISCORD_CLIENT_SECRET is not set")
+	}
+
 	return &config.ContestantAPI{
 		Address: opts.ContestantHTTPAddr,
+		Auth: config.ContestantAuth{
+			BaseURL:             &opts.ContestantBaseURL,
+			DiscordClientID:     discordClientID,
+			DiscordClientSecret: discordClientSecret,
+		},
 	}, nil
 }

--- a/backend/cmd/scoreserver/option.go
+++ b/backend/cmd/scoreserver/option.go
@@ -43,8 +43,8 @@ func NewOption(fs *flag.FlagSet) *CLIOption {
 	fs.StringVar(&opt.AdminAuthPolicyFile, "admin.auth-policy-file", "", "Admin API authorization policy file")
 
 	fs.TextVar(&opt.ContestantHTTPAddr, "contestant.http-addr", netip.MustParseAddrPort("127.0.0.1:8080"), "Contestant HTTP server address")
-	opt.ContestantBaseURL = url.URL{Scheme: "http", Host: "localhost:8080"}
-	fs.Var((*urlValue)(&opt.ContestantBaseURL), "contestant.base-url", "Contestant base URL")
+	fs.TextVar((*urlValue)(&opt.ContestantBaseURL), "contestant.base-url",
+		(*urlValue)(&url.URL{Scheme: "http", Host: "localhost:8080"}), "Contestant base URL")
 
 	fs.BoolFunc("v", "Verbose logging", func(string) error {
 		opt.LogLevel = slog.LevelDebug
@@ -66,8 +66,8 @@ func NewOption(fs *flag.FlagSet) *CLIOption {
 
 type urlValue url.URL
 
-func (v *urlValue) Set(s string) error {
-	u, err := url.Parse(s)
+func (v *urlValue) UnmarshalText(text []byte) error {
+	u, err := url.Parse(string(text))
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -75,6 +75,6 @@ func (v *urlValue) Set(s string) error {
 	return nil
 }
 
-func (v *urlValue) String() string {
-	return (*url.URL)(v).String()
+func (v *urlValue) MarshalText() ([]byte, error) {
+	return []byte((*url.URL)(v).String()), nil
 }

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -26,12 +26,14 @@ require (
 	github.com/phsym/console-slog v0.3.1
 	github.com/prometheus/client_golang v1.20.5
 	github.com/rbcervilla/redisstore/v9 v9.0.0
+	github.com/redis/go-redis/extra/redisotel/v9 v9.7.0
 	github.com/redis/go-redis/v9 v9.7.0
 	github.com/samber/slog-formatter v1.2.0
 	github.com/sqldef/sqldef v0.17.30
 	github.com/testcontainers/testcontainers-go v0.35.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.35.0
 	github.com/testcontainers/testcontainers-go/modules/redis v0.35.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.59.0
 	go.opentelemetry.io/otel v1.34.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.34.0
@@ -158,6 +160,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/quic-go/quic-go v0.49.0 // indirect
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.7.0 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
@@ -185,7 +188,6 @@ require (
 	go.lsp.dev/uri v0.3.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -352,6 +352,10 @@ github.com/quic-go/quic-go v0.49.0 h1:w5iJHXwHxs1QxyBv1EHKuC50GX5to8mJAxvtnttJp9
 github.com/quic-go/quic-go v0.49.0/go.mod h1:s2wDnmCdooUQBmQfpUSTCYBl1/D4FcqbULMMkASvR6s=
 github.com/rbcervilla/redisstore/v9 v9.0.0 h1:wOPbBaydbdxzi1gTafDftCI/Z7vnsXw0QDPCuhiMG0g=
 github.com/rbcervilla/redisstore/v9 v9.0.0/go.mod h1:q/acLpoKkTZzIsBYt0R4THDnf8W/BH6GjQYvxDSSfdI=
+github.com/redis/go-redis/extra/rediscmd/v9 v9.7.0 h1:BIx9TNZH/Jsr4l1i7VVxnV0JPiwYj8qyrHyuL0fGZrk=
+github.com/redis/go-redis/extra/rediscmd/v9 v9.7.0/go.mod h1:eTg/YQtGYAZD5r3DlGlJptJ45AHA+/G+2NPn30PKzik=
+github.com/redis/go-redis/extra/redisotel/v9 v9.7.0 h1:bQk8xiVFw+3ln4pfELVktpWgYdFpgLLU+quwSoeIof0=
+github.com/redis/go-redis/extra/redisotel/v9 v9.7.0/go.mod h1:0LyN+GHLIJmKtjYRPF7nHyTTMV6E91YngoOopNifQRo=
 github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=
 github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=

--- a/backend/scoreserver/config/config.go
+++ b/backend/scoreserver/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"net/netip"
+	"net/url"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/redis/go-redis/v9"
@@ -39,6 +40,14 @@ type AdminAuthz struct {
 	Policy string
 }
 
-type ContestantAPI struct {
-	Address netip.AddrPort
-}
+type (
+	ContestantAPI struct {
+		Address netip.AddrPort
+		Auth    ContestantAuth
+	}
+	ContestantAuth struct {
+		BaseURL             *url.URL
+		DiscordClientID     string
+		DiscordClientSecret string
+	}
+)

--- a/backend/scoreserver/contestant/auth.go
+++ b/backend/scoreserver/contestant/auth.go
@@ -1,0 +1,247 @@
+package contestant
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/gofrs/uuid/v5"
+	"github.com/gorilla/sessions"
+	"github.com/ictsc/ictsc-regalia/backend/scoreserver/config"
+	"github.com/ictsc/ictsc-regalia/backend/scoreserver/contestant/session"
+	"github.com/ictsc/ictsc-regalia/backend/scoreserver/domain"
+	"github.com/ictsc/ictsc-regalia/backend/scoreserver/infra/discord"
+	"github.com/ictsc/ictsc-regalia/backend/scoreserver/infra/pg"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"golang.org/x/oauth2"
+)
+
+type (
+	AuthHandler struct {
+		handler http.Handler
+		once    sync.Once
+
+		BaseURL               *url.URL
+		DiscordOAuth2Config   oauth2.Config
+		DiscordCallbackEffect DiscordCallbackEffect
+	}
+	DiscordCallbackEffect interface {
+		domain.DiscordIdentityGetter
+		domain.DiscordLinkedUserGetter
+	}
+	oauthErrorCode string
+)
+
+const (
+	oauthErrorInvalidRequest         oauthErrorCode = "invalid_request"
+	oauthErrorInvalidClient          oauthErrorCode = "invalid_client"
+	oauthErrorInvalidGrant           oauthErrorCode = "invalid_grant"
+	oauthErrorUnauthorizedClient     oauthErrorCode = "unauthorized_client"
+	oauthErrorUnsupportedGrantType   oauthErrorCode = "unsupported_grant_type"
+	oauthErrorInvalidScope           oauthErrorCode = "invalid_scope"
+	oauthErrorServerError            oauthErrorCode = "server_error"
+	oauthErrorTemporarilyUnavailable oauthErrorCode = "temporarily_unavailable"
+
+	authCookieAge   = 10 * time.Minute
+	signUpCookieAge = 10 * time.Minute
+	userCookieAge   = 3 * 24 * time.Hour
+)
+
+func newAuthHandler(cfg config.ContestantAuth, repo *pg.Repository) *AuthHandler {
+	return &AuthHandler{
+		BaseURL: cfg.BaseURL,
+		DiscordOAuth2Config: oauth2.Config{
+			ClientID:     cfg.DiscordClientID,
+			ClientSecret: cfg.DiscordClientSecret,
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  "https://discord.com/oauth2/authorize",
+				TokenURL: "https://discord.com/api/oauth2/token",
+			},
+			RedirectURL: cfg.BaseURL.JoinPath("./auth/callback").String(),
+			Scopes:      []string{"identify"},
+		},
+		DiscordCallbackEffect: struct {
+			*discord.UserClient
+			*pg.Repository
+		}{
+			UserClient: &discord.UserClient{HTTPClient: otelhttp.DefaultClient},
+			Repository: repo,
+		},
+	}
+}
+
+func (h *AuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.once.Do(func() {
+		mux := http.NewServeMux()
+		mux.Handle("GET /auth/signin",
+			otelhttp.WithRouteTag("/auth/signin", http.HandlerFunc(h.handleSignIn)))
+		mux.Handle("GET /auth/callback",
+			otelhttp.WithRouteTag("/auth/callback", http.HandlerFunc(h.handleCallback)))
+		h.handler = mux
+	})
+	h.handler.ServeHTTP(w, r)
+}
+
+func (h *AuthHandler) handleSignIn(w http.ResponseWriter, r *http.Request) {
+	nextPathURL := &url.URL{Path: "/"}
+	if nextPath := r.URL.Query().Get("next"); nextPath != "" {
+		url, err := parsePath(nextPath)
+		if err == nil {
+			nextPathURL = url
+		}
+	}
+
+	sess := h.generateOAuth2Session(nextPathURL)
+	h.discordAuthCodeURLRedirect(w, r, sess)
+}
+
+func (h *AuthHandler) generateOAuth2Session(nextPath *url.URL) *session.OAuth2Session {
+	return &session.OAuth2Session{
+		State:    oauth2.GenerateVerifier(),
+		Verifier: oauth2.GenerateVerifier(),
+		NextPath: nextPath,
+	}
+}
+
+func (h *AuthHandler) discordAuthCodeURLRedirect(w http.ResponseWriter, r *http.Request, sess *session.OAuth2Session) {
+	authCodeURL := h.DiscordOAuth2Config.AuthCodeURL(
+		sess.State,
+		oauth2.S256ChallengeOption(sess.Verifier),
+	)
+	if err := session.OAuth2SessionStore.Write(r, w, sess, &sessions.Options{
+		MaxAge:   int(authCookieAge.Seconds()),
+		Path:     h.BaseURL.JoinPath("./auth").Path,
+		Secure:   h.BaseURL.Scheme == "https",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	}); err != nil {
+		slog.ErrorContext(r.Context(), "failed to write oauth2 session", "error", errors.WithStack(err))
+		h.error(w, r, sess.NextPath, oauthErrorServerError)
+		return
+	}
+
+	http.Redirect(w, r, authCodeURL, http.StatusFound)
+}
+
+func (h *AuthHandler) handleCallback(w http.ResponseWriter, r *http.Request) {
+	// Get session
+	oauthSess, err := session.OAuth2SessionStore.Get(r.Context())
+	if err != nil {
+		if typ := domain.ErrTypeFrom(err); typ == domain.ErrTypeNotFound {
+			h.error(w, r, &url.URL{Path: "/"}, oauthErrorInvalidRequest)
+			return
+		}
+		slog.ErrorContext(r.Context(), "failed to get session", "error", errors.WithStack(err))
+		h.error(w, r, &url.URL{Path: "/"}, oauthErrorServerError)
+		return
+	}
+
+	// Delete session
+	if err := session.OAuth2SessionStore.Write(r, w, nil, nil); err != nil {
+		slog.ErrorContext(r.Context(), "failed to delete session", "error", errors.WithStack(err))
+		h.error(w, r, oauthSess.NextPath, oauthErrorServerError)
+		return
+	}
+
+	// Exchange auth code
+	if r.URL.Query().Get("state") != oauthSess.State {
+		h.error(w, r, oauthSess.NextPath, oauthErrorInvalidRequest)
+		return
+	}
+
+	if queryErr := r.URL.Query().Get("error"); queryErr != "" {
+		desc := r.URL.Query().Get("error_description")
+		slog.InfoContext(r.Context(), "failed to get discord callback", "error", queryErr, "error_description", desc)
+		h.error(w, r, oauthSess.NextPath, oauthErrorCode(queryErr))
+		return
+	}
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		h.error(w, r, oauthSess.NextPath, oauthErrorInvalidRequest)
+		return
+	}
+
+	token, err := h.DiscordOAuth2Config.Exchange(
+		context.WithValue(r.Context(), oauth2.HTTPClient, otelhttp.DefaultClient),
+		code, oauth2.VerifierOption(oauthSess.Verifier),
+	)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to exchange code", "error", errors.WithStack(err))
+		h.error(w, r, oauthSess.NextPath, oauthErrorServerError)
+		return
+	}
+
+	identity, err := domain.GetDiscordIdentity(r.Context(), h.DiscordCallbackEffect, token.AccessToken)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to get discord identity", "error", err)
+		h.error(w, r, oauthSess.NextPath, oauthErrorServerError)
+		return
+	}
+
+	user, err := identity.ID().User(r.Context(), h.DiscordCallbackEffect)
+	if err != nil && domain.ErrTypeFrom(err) != domain.ErrTypeNotFound {
+		slog.ErrorContext(r.Context(), "failed to get discord linked user", "error", err)
+		h.error(w, r, oauthSess.NextPath, oauthErrorServerError)
+		return
+	}
+	sessOpt := &sessions.Options{
+		Path:     h.BaseURL.Path,
+		Secure:   h.BaseURL.Scheme == "https",
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+	}
+	if user != nil {
+		// 登録済み
+		userSess := &session.UserSession{UserID: uuid.UUID(user.ID())}
+		sessOpt.MaxAge = int(userCookieAge.Seconds())
+		if err := session.UserSessionStore.Write(r, w, userSess, sessOpt); err != nil {
+			slog.ErrorContext(r.Context(), "failed to write user session", "error", err)
+			h.error(w, r, oauthSess.NextPath, oauthErrorServerError)
+			return
+		}
+	} else {
+		signUpSess := &session.SignUpSession{Discord: identity.Data()}
+		sessOpt.MaxAge = int(signUpCookieAge.Seconds())
+		if err := session.SignUpSessionStore.Write(r, w, signUpSess, sessOpt); err != nil {
+			slog.ErrorContext(r.Context(), "failed to write signup session", "error", err)
+			h.error(w, r, oauthSess.NextPath, oauthErrorServerError)
+			return
+		}
+	}
+
+	http.Redirect(w, r, oauthSess.NextPath.String(), http.StatusFound)
+}
+
+func (h *AuthHandler) error(w http.ResponseWriter, r *http.Request, nextPath *url.URL, errCode oauthErrorCode) {
+	frag := url.Values{}
+	frag.Set("oauth-error", string(errCode))
+	nextPath.Fragment = frag.Encode()
+	http.Redirect(w, r, nextPath.String(), http.StatusFound)
+}
+
+func parsePath(path string) (*url.URL, error) {
+	if !strings.HasPrefix(path, "/") {
+		return nil, errors.New("path must start with /")
+	}
+
+	parsedURL, err := url.Parse(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse path")
+	}
+
+	if parsedURL.RawQuery != "" {
+		return nil, errors.New("next path must not contain query")
+	}
+
+	if parsedURL.Host != "" {
+		return nil, errors.New("next path must not contain host")
+	}
+
+	return parsedURL, nil
+}

--- a/backend/scoreserver/contestant/server.go
+++ b/backend/scoreserver/contestant/server.go
@@ -9,13 +9,18 @@ import (
 	"github.com/ictsc/ictsc-regalia/backend/pkg/connectutil"
 	"github.com/ictsc/ictsc-regalia/backend/pkg/proto/contestant/v1/contestantv1connect"
 	"github.com/ictsc/ictsc-regalia/backend/scoreserver/config"
+	"github.com/ictsc/ictsc-regalia/backend/scoreserver/contestant/session"
+	"github.com/ictsc/ictsc-regalia/backend/scoreserver/infra/pg"
+	"github.com/jmoiron/sqlx"
 	"github.com/rbcervilla/redisstore/v9"
 	"github.com/redis/go-redis/v9"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 )
 
-func New(ctx context.Context, cfg config.ContestantAPI, rdb redis.UniversalClient) (http.Handler, error) {
+func New(ctx context.Context, cfg config.ContestantAPI, db *sqlx.DB, rdb redis.UniversalClient) (http.Handler, error) {
+	repo := pg.NewRepository(db)
 	sessionStore, err := redisstore.NewRedisStore(ctx, rdb)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create session store")
@@ -29,12 +34,15 @@ func New(ctx context.Context, cfg config.ContestantAPI, rdb redis.UniversalClien
 
 	mux := http.NewServeMux()
 
+	mux.Handle("/auth/", otelhttp.NewHandler(newAuthHandler(cfg.Auth, repo), "auth"))
+
 	mux.Handle(contestantv1connect.NewViewerServiceHandler(
 		contestantv1connect.UnimplementedViewerServiceHandler{},
 		connect.WithInterceptors(interceptors...),
 	))
 
 	handler := http.Handler(mux)
+	handler = session.NewHandler(sessionStore)(handler)
 	handler = h2c.NewHandler(handler, &http2.Server{})
 
 	return handler, nil

--- a/backend/scoreserver/contestant/session/session.go
+++ b/backend/scoreserver/contestant/session/session.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/gob"
 	"net/http"
+	"net/url"
 
 	"github.com/cockroachdb/errors"
+	"github.com/gofrs/uuid/v5"
 	"github.com/gorilla/sessions"
 	"github.com/ictsc/ictsc-regalia/backend/scoreserver/domain"
 )
@@ -14,10 +16,13 @@ type (
 	OAuth2Session struct {
 		State    string
 		Verifier string
+		NextPath *url.URL
 	}
 	SignUpSession struct {
-		InvitationCode string
-		Discord        *domain.DiscordIdentityData
+		Discord *domain.DiscordIdentityData
+	}
+	UserSession struct {
+		UserID uuid.UUID
 	}
 
 	sessionCtxKey struct{}
@@ -31,6 +36,8 @@ type (
 func init() {
 	gob.Register(&OAuth2Session{})
 	gob.Register(&SignUpSession{})
+	gob.Register(&domain.DiscordIdentityData{})
+	gob.Register(&UserSession{})
 }
 
 func NewHandler(store sessions.Store) func(http.Handler) http.Handler {
@@ -49,6 +56,7 @@ func NewHandler(store sessions.Store) func(http.Handler) http.Handler {
 var (
 	OAuth2SessionStore = &SessionStore[*OAuth2Session]{key: "oauth2-session"}
 	SignUpSessionStore = &SessionStore[*SignUpSession]{key: "signup-session"}
+	UserSessionStore   = &SessionStore[*UserSession]{key: "user-session"}
 )
 
 type SessionStore[V comparable] struct {

--- a/backend/scoreserver/domain/error.go
+++ b/backend/scoreserver/domain/error.go
@@ -45,11 +45,10 @@ func NewError(typ ErrType, err error) error {
 }
 
 func WrapAsInternal(err error, msg string) error {
-	wrappedErr := errors.WrapWithDepth(1, err, msg)
 	if errors.Is(err, &Error{}) {
-		return wrappedErr
+		return err
 	} else {
-		return NewError(ErrTypeInternal, wrappedErr)
+		return NewError(ErrTypeInternal, errors.WrapWithDepth(1, err, msg))
 	}
 }
 
@@ -59,6 +58,11 @@ func (e *Error) Error() string {
 
 func (e *Error) Unwrap() error {
 	return e.err
+}
+
+func (e *Error) Is(target error) bool {
+	t, ok := target.(*Error)
+	return ok && (t.typ == ErrTypeUnknown || t.typ == e.typ)
 }
 
 func ErrTypeFrom(err error) ErrType {

--- a/backend/scoreserver/domain/user.go
+++ b/backend/scoreserver/domain/user.go
@@ -11,6 +11,7 @@ import (
 )
 
 type (
+	UserID      = userID
 	UserName    = userName
 	User        = user
 	UserProfile = userProfile
@@ -22,6 +23,10 @@ func NewUserName(name string) (UserName, error) {
 
 func (n UserName) User(ctx context.Context, eff UserLister) (*User, error) {
 	return getUser(ctx, eff, UserListFilter{Name: string(n)})
+}
+
+func (u *User) ID() UserID {
+	return u.userID
 }
 
 func (u *User) Name() UserName {

--- a/backend/scoreserver/infra/discord/client.go
+++ b/backend/scoreserver/infra/discord/client.go
@@ -1,3 +1,7 @@
 package discord
 
-type UserClient struct{}
+import "net/http"
+
+type UserClient struct {
+	HTTPClient *http.Client
+}

--- a/backend/scoreserver/infra/discord/identity.go
+++ b/backend/scoreserver/infra/discord/identity.go
@@ -11,12 +11,15 @@ import (
 var _ domain.DiscordIdentityGetter = (*UserClient)(nil)
 
 func (c *UserClient) GetIdentity(ctx context.Context, token string) (*domain.DiscordIdentityData, error) {
-	session, err := discordgo.New("Bot " + token)
+	session, err := discordgo.New("Bearer " + token)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create discord session")
 	}
+	if c.HTTPClient != nil {
+		session.Client = c.HTTPClient
+	}
 
-	user, err := session.User("@me")
+	user, err := session.User("@me", discordgo.WithContext(ctx))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get user")
 	}

--- a/backend/scoreserver/scoreserver.go
+++ b/backend/scoreserver/scoreserver.go
@@ -44,7 +44,7 @@ func New(ctx context.Context, cfg *config.Config) (*ScoreServer, error) {
 		MaxHeaderBytes:    maxHeaderBytes,
 	}
 
-	contestantHandler, err := contestant.New(ctx, cfg.ContestantAPI, rdb)
+	contestantHandler, err := contestant.New(ctx, cfg.ContestantAPI, db, rdb)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
closes #52

Discord OAuth2 を使ったログインを実装した

既にユーザーが登録されているならログインしてユーザーセッションを設定し，未登録であるならば OAuth2 で得た Discord のユーザー情報を持った登録用セッションを設定する