### PR TITLE
chore: use go tools

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -37,7 +37,7 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN --mount=type=bind,source=go.mod,target=go.mod \
 <<-EOS
-SQLDEF_VERSION="$(grep github.com/sqldef/sqldef go.mod | cut -d" " -f2)"
+SQLDEF_VERSION="$(grep github.com/sqldef/sqldef go.mod | cut -d" " -f2 | head -n1)"
 curl -fsSL -o psqldef.tar.gz "https://github.com/sqldef/sqldef/releases/download/${SQLDEF_VERSION}/psqldef_${TARGETOS}_${TARGETARCH}.tar.gz"
 tar -xf psqldef.tar.gz -C /usr/local/bin
 rm psqldef.tar.gz

--- a/backend/buf.gen.yaml
+++ b/backend/buf.gen.yaml
@@ -5,9 +5,9 @@ clean: true
 inputs:
   - directory: ../proto
 plugins:
-  - local: ["go", "run", "google.golang.org/protobuf/cmd/protoc-gen-go"]
+  - local: ["go", "tool", "google.golang.org/protobuf/cmd/protoc-gen-go"]
     out: pkg/proto
     opt: paths=source_relative
-  - local: ["go", "run", "connectrpc.com/connect/cmd/protoc-gen-connect-go"]
+  - local: ["go", "tool", "connectrpc.com/connect/cmd/protoc-gen-connect-go"]
     out: pkg/proto
     opt: paths=source_relative

--- a/backend/generate.go
+++ b/backend/generate.go
@@ -1,3 +1,3 @@
 package main
 
-//go:generate go run github.com/bufbuild/buf/cmd/buf generate --template buf.gen.yaml
+//go:generate go tool github.com/bufbuild/buf/cmd/buf generate --template buf.gen.yaml

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,8 +1,6 @@
 module github.com/ictsc/ictsc-regalia/backend
 
-go 1.23.0
-
-toolchain go1.24.0
+go 1.24.0
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.3-20241127180247-a33202765966.1
@@ -11,7 +9,6 @@ require (
 	connectrpc.com/otelconnect v0.7.1
 	github.com/DATA-DOG/go-txdb v0.2.0
 	github.com/XSAM/otelsql v0.36.0
-	github.com/bufbuild/buf v1.50.0
 	github.com/bwmarrin/discordgo v0.28.1
 	github.com/casbin/casbin/v2 v2.103.0
 	github.com/cockroachdb/errors v1.11.3
@@ -29,7 +26,6 @@ require (
 	github.com/redis/go-redis/extra/redisotel/v9 v9.7.0
 	github.com/redis/go-redis/v9 v9.7.0
 	github.com/samber/slog-formatter v1.2.0
-	github.com/sqldef/sqldef v0.17.30
 	github.com/testcontainers/testcontainers-go v0.35.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.35.0
 	github.com/testcontainers/testcontainers-go/modules/redis v0.35.0
@@ -70,6 +66,7 @@ require (
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.8.1 // indirect
+	github.com/bufbuild/buf v1.50.0 // indirect
 	github.com/bufbuild/protocompile v0.14.1 // indirect
 	github.com/bufbuild/protoplugin v0.0.0-20250106231243-3a819552c9d9 // indirect
 	github.com/bufbuild/protovalidate-go v0.8.2 // indirect
@@ -174,6 +171,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/sqldef/sqldef v0.17.30 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/tetratelabs/wazero v1.8.2 // indirect
@@ -206,4 +204,11 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250207221924-e9438ea467c6 // indirect
 	google.golang.org/grpc v1.70.0 // indirect
 	pluginrpc.com/pluginrpc v0.5.0 // indirect
+)
+
+tool (
+	connectrpc.com/connect/cmd/protoc-gen-connect-go
+	github.com/bufbuild/buf/cmd/buf
+	github.com/sqldef/sqldef/cmd/psqldef
+	google.golang.org/protobuf/cmd/protoc-gen-go
 )

--- a/backend/scripts/migrate
+++ b/backend/scripts/migrate
@@ -1,7 +1,7 @@
 #!/bin/sh
 # vim: ft=sh :
 
-PSQLDEF="go run github.com/sqldef/sqldef/cmd/psqldef"
+PSQLDEF="go tool github.com/sqldef/sqldef/cmd/psqldef"
 if which psqldef 2>/dev/null; then
     PSQLDEF=psqldef
 fi

--- a/backend/tools.go
+++ b/backend/tools.go
@@ -1,9 +1,0 @@
-//go:build tools
-package main
-
-import (
-	_ "github.com/bufbuild/buf/cmd/buf"
-	_ "github.com/sqldef/sqldef/cmd/psqldef"
-	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
-	_ "connectrpc.com/connect/cmd/protoc-gen-connect-go"
-)


### PR DESCRIPTION
Go 1.24 から導入された go.mod の tool directive を使ってツール類を管理するようにする

手元の Go のバージョンが古くても go tool コマンドは既に存在することと，ツールチェインの自動ダウンロード機能によって使うことができる(Go 1.23.6 で確認した)