### PR TITLE
fix: handle empty cookie path as root path

### DIFF
--- a/backend/scoreserver/contestant/auth.go
+++ b/backend/scoreserver/contestant/auth.go
@@ -190,8 +190,13 @@ func (h *AuthHandler) handleCallback(w http.ResponseWriter, r *http.Request) {
 		h.error(w, r, oauthSess.NextPath, oauthErrorServerError)
 		return
 	}
+
+	path := h.BaseURL.Path
+	if path == "" {
+		path = "/"
+	}
 	sessOpt := &sessions.Options{
-		Path:     h.BaseURL.Path,
+		Path:     path,
 		Secure:   h.BaseURL.Scheme == "https",
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,


### PR DESCRIPTION
BaseURL.Pathが空の場合、クッキーの正しい処理を確実にするためにクッキーのパスを"/"に設定します。
これにより、パスが空の場合にクッキーが正しく設定されない問題が修正されます。
