### PR TITLE
feat: contestant signup

### DIFF
--- a/backend/pkg/ratelimiter/redis.go
+++ b/backend/pkg/ratelimiter/redis.go
@@ -1,0 +1,53 @@
+package ratelimiter
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/redis/go-redis/v9"
+)
+
+type RateLimiter interface {
+	Check(ctx context.Context, key string, window time.Duration, maxAttempts int) (bool, error)
+}
+
+type RedisRateLimiter struct {
+	rdb    redis.UniversalClient
+	prefix string
+}
+
+func NewRedisRateLimiter(rdb redis.UniversalClient, prefix string) *RedisRateLimiter {
+	if prefix == "" {
+		prefix = "rate_limit:"
+	}
+	return &RedisRateLimiter{
+		rdb:    rdb,
+		prefix: prefix,
+	}
+}
+
+func (r *RedisRateLimiter) Check(ctx context.Context, key string, window time.Duration, maxAttempts int) (bool, error) {
+	key = r.prefix + key
+	now := time.Now().Unix()
+	windowSeconds := window.Seconds()
+
+	pipe := r.rdb.Pipeline()
+
+	// 有効期限切れのエントリを削除
+	pipe.ZRemRangeByScore(ctx, key, "0", strconv.FormatInt(now-int64(windowSeconds), 10))
+	// 現在の試行を記録
+	pipe.ZAdd(ctx, key, redis.Z{Score: float64(now), Member: now})
+	// 現在の試行回数を取得
+	countCmd := pipe.ZCard(ctx, key)
+	// 有効期限を設定
+	pipe.Expire(ctx, key, window)
+
+	if _, err := pipe.Exec(ctx); err != nil {
+		return false, errors.Wrap(err, "failed to execute redis pipeline")
+	}
+
+	attempts := countCmd.Val()
+	return attempts <= int64(maxAttempts), nil
+}

--- a/backend/pkg/ratelimiter/redis_test.go
+++ b/backend/pkg/ratelimiter/redis_test.go
@@ -1,0 +1,82 @@
+package ratelimiter_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ictsc/ictsc-regalia/backend/pkg/ratelimiter"
+	"github.com/ictsc/ictsc-regalia/backend/pkg/redistest"
+)
+
+func TestRedisRateLimiter(t *testing.T) {
+	t.Parallel()
+	rdb := redistest.SetupRedis(t)
+	limiter := ratelimiter.NewRedisRateLimiter(rdb, "test:")
+
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+
+		window := 10 * time.Second
+		maxAttempts := 3
+
+		for i := range 3 {
+			ok, err := limiter.Check(t.Context(), t.Name(), window, maxAttempts)
+			if err != nil {
+				t.Fatalf("attempt %d: %+v", i, err)
+			}
+			if !ok {
+				t.Errorf("attempt %d: expected ok, but not ok", i)
+			}
+			time.Sleep(time.Second)
+		}
+	})
+
+	t.Run("rate limit", func(t *testing.T) {
+		t.Parallel()
+
+		window := 10 * time.Second
+		maxAttempts := 0
+
+		ok, err := limiter.Check(t.Context(), t.Name(), window, maxAttempts)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		if ok {
+			t.Errorf("expected not ok, but ok")
+		}
+	})
+
+	t.Run("sliding window", func(t *testing.T) {
+		t.Parallel()
+
+		window := 5 * time.Second
+		maxAttempts := 2
+
+		// time: 0
+		// 最初に2回試行
+		for i := range 2 {
+			if ok, err := limiter.Check(t.Context(), t.Name(), window, maxAttempts); err != nil {
+				t.Fatalf("attempt %d: %+v", i, err)
+			} else if !ok {
+				t.Fatalf("attempt %d: expected ok, but not ok", i)
+			}
+			time.Sleep(time.Second)
+		}
+		// time: 2
+		// 3回目の試行は失敗する
+		if ok, err := limiter.Check(t.Context(), t.Name(), window, maxAttempts); err != nil {
+			t.Fatalf("%+v", err)
+		} else if ok {
+			t.Fatalf("expected not ok, but ok")
+		}
+
+		time.Sleep(5 * time.Second)
+		// time: 7
+		// 3回目の試行だけが記録に残っているので4回目は成功する
+		if ok, err := limiter.Check(t.Context(), t.Name(), window, maxAttempts); err != nil {
+			t.Fatalf("%+v", err)
+		} else if !ok {
+			t.Fatalf("expected ok, but not ok")
+		}
+	})
+}

--- a/backend/scoreserver/contestant/auth.go
+++ b/backend/scoreserver/contestant/auth.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/gofrs/uuid/v5"
 	"github.com/gorilla/sessions"
+	"github.com/ictsc/ictsc-regalia/backend/pkg/ratelimiter"
 	"github.com/ictsc/ictsc-regalia/backend/scoreserver/config"
 	"github.com/ictsc/ictsc-regalia/backend/scoreserver/contestant/session"
 	"github.com/ictsc/ictsc-regalia/backend/scoreserver/domain"
@@ -28,6 +29,7 @@ type (
 
 		BaseURL             *url.URL
 		DiscordOAuth2Config oauth2.Config
+		RateLimiter         ratelimiter.RateLimiter
 
 		DiscordCallbackEffect DiscordCallbackEffect
 		SignUpEffect          SignUpEffect
@@ -56,7 +58,7 @@ const (
 	userCookieAge   = 3 * 24 * time.Hour
 )
 
-func newAuthHandler(cfg config.ContestantAuth, repo *pg.Repository) *AuthHandler {
+func newAuthHandler(cfg config.ContestantAuth, repo *pg.Repository, rateLimiter ratelimiter.RateLimiter) *AuthHandler {
 	return &AuthHandler{
 		BaseURL: cfg.BaseURL,
 		DiscordOAuth2Config: oauth2.Config{
@@ -69,6 +71,7 @@ func newAuthHandler(cfg config.ContestantAuth, repo *pg.Repository) *AuthHandler
 			RedirectURL: cfg.BaseURL.JoinPath("./auth/callback").String(),
 			Scopes:      []string{"identify"},
 		},
+		RateLimiter: rateLimiter,
 
 		DiscordCallbackEffect: struct {
 			*discord.UserClient

--- a/backend/scoreserver/contestant/auth_signup.go
+++ b/backend/scoreserver/contestant/auth_signup.go
@@ -67,7 +67,7 @@ func (h *AuthHandler) handleSignUp(w http.ResponseWriter, r *http.Request) {
 		writeJSON(r.Context(), w, SignUpResponse{Message: "no discord identity"})
 		return
 	}
-	if err := session.SignUpSessionStore.Write(r, w, nil, nil); err != nil {
+	if err := session.SignUpSessionStore.Write(r, w, nil, h.signUpSessionOption()); err != nil {
 		slog.ErrorContext(r.Context(), "failed to delete signup session", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		writeJSON(r.Context(), w, SignUpResponse{})

--- a/backend/scoreserver/contestant/auth_signup.go
+++ b/backend/scoreserver/contestant/auth_signup.go
@@ -1,0 +1,159 @@
+package contestant
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/gofrs/uuid/v5"
+	"github.com/ictsc/ictsc-regalia/backend/scoreserver/contestant/session"
+	"github.com/ictsc/ictsc-regalia/backend/scoreserver/domain"
+)
+
+type (
+	SignUpRequest struct {
+		InvitationCode string `json:"invitation_code"`
+		Name           string `json:"name"`
+		DisplayName    string `json:"display_name"`
+	}
+	SignUpResponse struct {
+		Message string            `json:"message,omitempty"`
+		Codes   []SignUpErrorCode `json:"codes,omitempty"`
+	}
+	SignUpErrorCode string
+)
+
+const (
+	SignUpErrorCodeInvalidInvitationCode SignUpErrorCode = "invalid_invitation_code"
+	SignUpErrorCodeInvalidName           SignUpErrorCode = "invalid_name"
+	SignUpErrorCodeInvalidDisplayName    SignUpErrorCode = "invalid_display_name"
+
+	signUpRequestLimit = 1024
+)
+
+func (h *AuthHandler) handleSignUp(w http.ResponseWriter, r *http.Request) {
+	var req SignUpRequest
+	if r.Header.Get("Content-Type") != "application/json" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(r.Context(), w, SignUpResponse{Message: "Content-Type must be application/json"})
+		return
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, signUpRequestLimit)).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(r.Context(), w, SignUpResponse{})
+		return
+	}
+	_, _ = io.Copy(io.Discard, r.Body)
+
+	signUpSess, err := session.SignUpSessionStore.Get(r.Context())
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			w.WriteHeader(http.StatusBadRequest)
+			writeJSON(r.Context(), w, SignUpResponse{Message: "session not found"})
+			return
+		} else {
+			slog.ErrorContext(r.Context(), "failed to get signup session", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			writeJSON(r.Context(), w, SignUpResponse{})
+			return
+		}
+	}
+	if signUpSess.Discord == nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(r.Context(), w, SignUpResponse{Message: "no discord identity"})
+		return
+	}
+	if err := session.SignUpSessionStore.Write(r, w, nil, nil); err != nil {
+		slog.ErrorContext(r.Context(), "failed to delete signup session", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(r.Context(), w, SignUpResponse{})
+		return
+	}
+
+	userProfile, err := SignUp(r.Context(), h.SignUpEffect, time.Now(), &SignUpInput{
+		InvitationCode: req.InvitationCode,
+		Name:           req.Name,
+		DisplayName:    req.DisplayName,
+		DiscordID:      signUpSess.Discord.ID,
+	})
+	if err != nil {
+		// TODO: better error handling
+		slog.ErrorContext(r.Context(), "failed to sign up", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(r.Context(), w, SignUpResponse{})
+		return
+	}
+
+	userSess := &session.UserSession{UserID: uuid.UUID(userProfile.ID())}
+	sessOpt := h.sessionOption()
+	sessOpt.MaxAge = int(userCookieAge.Seconds())
+	if err := session.UserSessionStore.Write(r, w, userSess, sessOpt); err != nil {
+		slog.ErrorContext(r.Context(), "failed to write user session", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(r.Context(), w, SignUpResponse{})
+	}
+
+	w.WriteHeader(http.StatusOK)
+	writeJSON(r.Context(), w, SignUpResponse{})
+}
+
+func writeJSON(ctx context.Context, w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.ErrorContext(ctx, "failed to write json", "error", errors.WithStack(err))
+		http.Error(w, "{}", http.StatusInternalServerError)
+	}
+}
+
+type (
+	// SignUpEffect ユーザー登録処理に必要な依存
+	SignUpEffect   domain.Tx[SignUpTxEffect]
+	SignUpTxEffect interface {
+		domain.InvitationCodeReader
+		domain.UserCreator
+		domain.DiscordUserLinker
+		domain.TeamMemberManager
+	}
+	SignUpInput struct {
+		InvitationCode string
+		Name           string
+		DisplayName    string
+		DiscordID      string
+	}
+)
+
+func SignUp(ctx context.Context, effect SignUpEffect, now time.Time, input *SignUpInput) (*domain.UserProfile, error) {
+	discordUserID, err := domain.NewDiscordID(input.DiscordID)
+	if err != nil {
+		return nil, err
+	}
+	codeString := domain.InvitationCodeString(input.InvitationCode)
+
+	return domain.RunTx(ctx, effect, func(effect SignUpTxEffect) (*domain.UserProfile, error) {
+		var errs []error
+		userProfile, err := domain.CreateUser(ctx, effect, input.Name, input.DisplayName)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		invitationCode, err := codeString.Code(ctx, effect)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		if len(errs) > 0 {
+			return nil, errors.Join(errs...)
+		}
+
+		if err := userProfile.LinkDiscord(ctx, effect, discordUserID); err != nil {
+			return nil, err
+		}
+		if err := userProfile.JoinTeam(ctx, effect, now, invitationCode); err != nil {
+			return nil, err
+		}
+
+		return userProfile, nil
+	})
+}

--- a/backend/scoreserver/contestant/auth_signup_test.go
+++ b/backend/scoreserver/contestant/auth_signup_test.go
@@ -1,0 +1,61 @@
+package contestant_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/ictsc/ictsc-regalia/backend/pkg/pgtest"
+	"github.com/ictsc/ictsc-regalia/backend/scoreserver/contestant"
+	"github.com/ictsc/ictsc-regalia/backend/scoreserver/domain"
+	"github.com/ictsc/ictsc-regalia/backend/scoreserver/infra/pg"
+	"github.com/jmoiron/sqlx"
+)
+
+func TestSignUpOK(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	input := contestant.SignUpInput{
+		InvitationCode: "LHNZXGSF7L59WCG9",
+		Name:           "test",
+		DisplayName:    "Tester",
+		DiscordID:      "987654321987654321",
+	}
+
+	db := pgtest.SetupDB(t)
+	repo := pg.NewRepository(db)
+	effect := pg.Tx(repo, func(rt *pg.RepositoryTx) contestant.SignUpTxEffect { return rt })
+	userProfile, err := contestant.SignUp(t.Context(), effect, now, &input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(
+		userProfile.Data(), &domain.UserProfileData{
+			User: &domain.UserData{
+				Name: "test",
+			},
+			DisplayName: "Tester",
+		},
+		cmpopts.IgnoreFields(domain.UserData{}, "ID"),
+	); diff != "" {
+		t.Errorf("diff: %s", diff)
+	}
+
+	var result int
+	if err := sqlx.GetContext(t.Context(), db, &result, `
+		SELECT 1 FROM team_members AS tm
+		JOIN invitation_codes AS ic ON tm.invitation_code_id = ic.id
+		WHERE tm.user_id = $1 AND ic.code = $2`,
+		userProfile.User().ID(), "LHNZXGSF7L59WCG9",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := sqlx.GetContext(t.Context(), db, &result, `
+		SELECT 1 FROM discord_users WHERE user_id = $1 AND discord_user_id = $2`,
+		userProfile.User().ID(), "987654321987654321",
+	); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/scoreserver/contestant/auth_signup_test.go
+++ b/backend/scoreserver/contestant/auth_signup_test.go
@@ -1,6 +1,8 @@
 package contestant_test
 
 import (
+	"errors"
+	"strings"
 	"testing"
 	"time"
 

--- a/backend/scoreserver/contestant/session/session.go
+++ b/backend/scoreserver/contestant/session/session.go
@@ -99,13 +99,12 @@ func (s *SessionStore[V]) Write(r *http.Request, w http.ResponseWriter, val V, o
 	if err != nil {
 		return err
 	}
-
+	if options != nil {
+		sess.Options = options
+	}
 	var zero V
 	if val != zero {
 		sess.Values[0] = val
-		if options != nil {
-			sess.Options = options
-		}
 	} else {
 		sess.Options.MaxAge = -1
 	}

--- a/backend/scoreserver/domain/discord.go
+++ b/backend/scoreserver/domain/discord.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/cockroachdb/errors"
 	"github.com/gofrs/uuid/v5"
 )
 
@@ -81,14 +80,22 @@ type (
 	}
 )
 
-func (d *DiscordIdentityData) parse() (*DiscordIdentity, error) {
-	id, err := strconv.ParseInt(d.ID, 10, 64)
+func NewDiscordID(id string) (DiscordUserID, error) {
+	i, err := strconv.ParseInt(id, 10, 64)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse discord user id")
+		return 0, NewInvalidArgumentError("invalid discord user id", err)
+	}
+	return DiscordUserID(i), nil
+}
+
+func (d *DiscordIdentityData) parse() (*DiscordIdentity, error) {
+	id, err := NewDiscordID(d.ID)
+	if err != nil {
+		return nil, err
 	}
 
 	return &DiscordIdentity{
-		id:         DiscordUserID(id),
+		id:         id,
 		username:   d.Username,
 		globalName: d.GlobalName,
 	}, nil

--- a/backend/scoreserver/domain/error.go
+++ b/backend/scoreserver/domain/error.go
@@ -92,7 +92,9 @@ func (e *Error) Unwrap() error {
 
 func (e *Error) Is(target error) bool {
 	t, ok := target.(*Error)
-	return ok && (t.Type == ErrTypeUnknown || t.Type == e.Type)
+	return ok &&
+		(t.Type == 0 || t.Type == e.Type) &&
+		(t.Msg == "" || t.Msg == e.Msg)
 }
 
 func ErrorType(err error) ErrType {

--- a/backend/scoreserver/domain/invitation.go
+++ b/backend/scoreserver/domain/invitation.go
@@ -51,9 +51,10 @@ func (t *Team) CreateInvitationCode(
 	return t.createInvitationCode(ctx, eff, now, expiresAt)
 }
 
-type InvitationCodeCreateEffect interface {
-	InvitationCodeCreator
-}
+var (
+	ErrInvitationCodeNotFound = NewNotFoundError("invitation code", nil)
+	ErrInvitationCodeExpired  = NewInvalidArgumentError("invitation code expired", nil)
+)
 
 type (
 	InvitationCodeData struct {

--- a/backend/scoreserver/domain/invitation_test.go
+++ b/backend/scoreserver/domain/invitation_test.go
@@ -103,7 +103,7 @@ func Test_CreateInvitationCode(t *testing.T) {
 
 	cases := map[string]struct {
 		team      *domain.Team
-		effect    domain.InvitationCodeCreateEffect
+		effect    domain.InvitationCodeCreator
 		expiresAt time.Time
 
 		want    *domain.InvitationCodeData

--- a/backend/scoreserver/domain/team_member_test.go
+++ b/backend/scoreserver/domain/team_member_test.go
@@ -51,7 +51,7 @@ func TestJoinTeam(t *testing.T) {
 			}),
 			inTeamMemberCount: 0,
 
-			wantErr: domain.ErrInvalidArgument,
+			wantErr: domain.ErrInvitationCodeExpired,
 		},
 		"full member": {
 			inUser: domain.FixUser1(t, nil),
@@ -60,7 +60,7 @@ func TestJoinTeam(t *testing.T) {
 			}),
 			inTeamMemberCount: 3,
 
-			wantErr: domain.ErrInvalidArgument,
+			wantErr: domain.ErrTeamIsFull,
 		},
 	}
 

--- a/backend/scoreserver/domain/tx.go
+++ b/backend/scoreserver/domain/tx.go
@@ -1,6 +1,10 @@
 package domain
 
-import "context"
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+)
 
 type Tx[E any] interface {
 	RunInTx(ctx context.Context, f func(E) error) error
@@ -10,4 +14,17 @@ type TxFunc[E any] func(context.Context, func(E) error) error
 
 func (t TxFunc[E]) RunInTx(ctx context.Context, f func(E) error) error {
 	return t(ctx, f)
+}
+
+func RunTx[V any, E any](ctx context.Context, tx Tx[E], fun func(E) (V, error)) (V, error) {
+	var val V
+	if tx == nil {
+		return val, errors.New("tx is nil")
+	}
+	err := tx.RunInTx(ctx, func(e E) error {
+		var err error
+		val, err = fun(e)
+		return err
+	})
+	return val, err
 }

--- a/backend/scoreserver/domain/user_test.go
+++ b/backend/scoreserver/domain/user_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"iter"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/errors"
 	"github.com/gofrs/uuid/v5"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/ictsc/ictsc-regalia/backend/scoreserver/domain"
 )
 
@@ -25,27 +27,27 @@ func TestUserNameValidation(t *testing.T) {
 		},
 		"no name": {
 			in:      "",
-			wantErr: domain.ErrInvalidArgument,
+			wantErr: domain.ErrInvalidUserName,
 		},
 		"too short name": {
 			in:      "a",
-			wantErr: domain.ErrInvalidArgument,
+			wantErr: domain.ErrInvalidUserName,
 		},
 		"too long name": {
 			in:      "abcdefghijklmnopqrstuvwxyz123456abc",
-			wantErr: domain.ErrInvalidArgument,
+			wantErr: domain.ErrInvalidUserName,
 		},
 		"invalid character name": {
 			in:      "🙆",
-			wantErr: domain.ErrInvalidArgument,
+			wantErr: domain.ErrInvalidUserName,
 		},
 		"repeated periods name": {
 			in:      "a..b",
-			wantErr: domain.ErrInvalidArgument,
+			wantErr: domain.ErrInvalidUserName,
 		},
 		"invalid character uppercase": {
 			in:      "ABC",
-			wantErr: domain.ErrInvalidArgument,
+			wantErr: domain.ErrInvalidUserName,
 		},
 	}
 
@@ -137,8 +139,90 @@ func TestGetUserByName(t *testing.T) {
 	}
 }
 
+func TestCreateUser(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		inName        string
+		inDisplayName string
+
+		want     *domain.UserProfileData
+		wantErrs []error
+	}{
+		"ok": {
+			inName:        "alice",
+			inDisplayName: "Alice",
+
+			want: &domain.UserProfileData{
+				User: &domain.UserData{
+					Name: "alice",
+				},
+				DisplayName: "Alice",
+			},
+		},
+		"invalid name": {
+			inName:        "アルファベットでない",
+			inDisplayName: "Alice",
+
+			wantErrs: []error{domain.ErrInvalidUserName},
+		},
+		"invalid display name": {
+			inName:        "alice",
+			inDisplayName: strings.Repeat("あ", 128),
+
+			wantErrs: []error{domain.ErrInvalidDisplayName},
+		},
+		"composite error": {
+			inName:        "アルファベットでない",
+			inDisplayName: strings.Repeat("あ", 128),
+
+			wantErrs: []error{domain.ErrInvalidUserName, domain.ErrInvalidDisplayName},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var createdProfile *domain.UserProfileData
+			effect := userCreateFunc(func(_ context.Context, profile *domain.UserProfileData) error {
+				createdProfile = profile
+				return nil
+			})
+
+			got, err := domain.CreateUser(t.Context(), effect, tt.inName, tt.inDisplayName)
+			if err == nil && len(tt.wantErrs) != 0 {
+				t.Error("unexpected success")
+			}
+			for _, wantErr := range tt.wantErrs {
+				if !errors.Is(err, wantErr) {
+					t.Errorf("want error %v, but got %v", wantErr, err)
+				}
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(createdProfile, got.Data()); diff != "" {
+				t.Errorf("(-created, +got)\n%s", diff)
+			}
+			if diff := cmp.Diff(
+				tt.want, got.Data(),
+				cmpopts.IgnoreFields(domain.UserData{}, "ID"),
+			); diff != "" {
+				t.Errorf("(-want, +got)\n%s", diff)
+			}
+		})
+	}
+}
+
 type userListerFunc func(context.Context, domain.UserListFilter) iter.Seq2[*domain.UserData, error]
 
 func (f userListerFunc) ListUsers(ctx context.Context, filter domain.UserListFilter) iter.Seq2[*domain.UserData, error] {
 	return f(ctx, filter)
+}
+
+type userCreateFunc func(context.Context, *domain.UserProfileData) error
+
+func (f userCreateFunc) CreateUser(ctx context.Context, profile *domain.UserProfileData) error {
+	return f(ctx, profile)
 }

--- a/backend/scoreserver/infra/pg/invitation_code.go
+++ b/backend/scoreserver/infra/pg/invitation_code.go
@@ -81,7 +81,7 @@ func (r *repo) GetInvitationCode(ctx context.Context, codeString string) (*domai
 		r.ext.Rebind(selectInvitationCode+" WHERE ic.code = ? LIMIT 1"), codeString,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, domain.NewNotFoundError("invitation_code", nil)
+			return nil, errors.WithStack(domain.ErrInvitationCodeNotFound)
 		}
 		return nil, domain.WrapAsInternal(err, "failed to select invitation_code")
 	}

--- a/backend/scoreserver/infra/pg/invitation_code_test.go
+++ b/backend/scoreserver/infra/pg/invitation_code_test.go
@@ -128,7 +128,7 @@ func TestGetInvitationCode(t *testing.T) {
 		},
 		"not found": {
 			code:    "notfound",
-			wantErr: domain.ErrNotFound,
+			wantErr: domain.ErrInvitationCodeNotFound,
 		},
 	}
 

--- a/backend/scoreserver/infra/pg/user_test.go
+++ b/backend/scoreserver/infra/pg/user_test.go
@@ -147,7 +147,7 @@ func Test_PgRepo_CreateUser(t *testing.T) {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		},
-		"重複していたらエラー": func(t *testing.T, repo *pg.Repository, _ *sqlx.DB) {
+		"duplicate name": func(t *testing.T, repo *pg.Repository, _ *sqlx.DB) {
 			ctx := t.Context()
 
 			profile := &domain.UserProfileData{
@@ -162,8 +162,8 @@ func Test_PgRepo_CreateUser(t *testing.T) {
 				return tx.CreateUser(ctx, profile)
 			})
 
-			if !errors.Is(err, domain.ErrAlreadyExists) {
-				t.Errorf("want error type %v, but got %v", domain.ErrAlreadyExists, err)
+			if !errors.Is(err, domain.ErrDuplicateUserName) {
+				t.Errorf("want error type %v, but got %v", domain.ErrDuplicateUserName, err)
 			}
 		},
 	}


### PR DESCRIPTION
競技者向け API にユーザー登録のためのエンドポイント(`/auth/signup`)を追加した

Cookie を制御するため，Connect API ではなく JSON API として作っている
また，ユーザー登録フォームから扱われることが想定されるため，できるだけ多くのエラーを返すようにしている
