### PR TITLE
feat: csrf protection

### DIFF
--- a/backend/cmd/scoreserver/config.go
+++ b/backend/cmd/scoreserver/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/cockroachdb/errors"
@@ -83,6 +84,8 @@ func newAdminConfig(opts *CLIOption) (*config.AdminAPI, error) {
 }
 
 func newContestantConfig(opts *CLIOption) (*config.ContestantAPI, error) {
+	origin := fmt.Sprintf("%s://%s", opts.ContestantBaseURL.Scheme, opts.ContestantBaseURL.Host)
+
 	discordClientID := os.Getenv("DISCORD_CLIENT_ID")
 	if discordClientID == "" {
 		return nil, errors.New("DISCORD_CLIENT_ID is not set")
@@ -93,7 +96,8 @@ func newContestantConfig(opts *CLIOption) (*config.ContestantAPI, error) {
 	}
 
 	return &config.ContestantAPI{
-		Address: opts.ContestantHTTPAddr,
+		Address:        opts.ContestantHTTPAddr,
+		AllowedOrigins: []string{origin},
 		Auth: config.ContestantAuth{
 			BaseURL:             &opts.ContestantBaseURL,
 			DiscordClientID:     discordClientID,

--- a/backend/pkg/httputil/csrf.go
+++ b/backend/pkg/httputil/csrf.go
@@ -1,0 +1,27 @@
+package httputil
+
+import (
+	"net/http"
+	"slices"
+)
+
+func CSRFMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet || r.Method == http.MethodHead {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if origin := r.Header.Get("Origin"); !slices.Contains(allowedOrigins, origin) {
+				http.Error(w, "", http.StatusForbidden)
+				return
+			}
+			if secFetchSite := r.Header.Get("Sec-Fetch-Site"); secFetchSite != "" && secFetchSite != "same-origin" {
+				http.Error(w, "", http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/backend/scoreserver/config/config.go
+++ b/backend/scoreserver/config/config.go
@@ -42,8 +42,9 @@ type AdminAuthz struct {
 
 type (
 	ContestantAPI struct {
-		Address netip.AddrPort
-		Auth    ContestantAuth
+		Address        netip.AddrPort
+		Auth           ContestantAuth
+		AllowedOrigins []string
 	}
 	ContestantAuth struct {
 		BaseURL             *url.URL

--- a/backend/scoreserver/contestant/server.go
+++ b/backend/scoreserver/contestant/server.go
@@ -7,6 +7,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/cockroachdb/errors"
 	"github.com/ictsc/ictsc-regalia/backend/pkg/connectutil"
+	"github.com/ictsc/ictsc-regalia/backend/pkg/httputil"
 	"github.com/ictsc/ictsc-regalia/backend/pkg/proto/contestant/v1/contestantv1connect"
 	"github.com/ictsc/ictsc-regalia/backend/pkg/ratelimiter"
 	"github.com/ictsc/ictsc-regalia/backend/scoreserver/config"
@@ -47,6 +48,7 @@ func New(ctx context.Context, cfg config.ContestantAPI, db *sqlx.DB, rdb redis.U
 
 	handler := http.Handler(mux)
 	handler = session.NewHandler(sessionStore)(handler)
+	handler = httputil.CSRFMiddleware(cfg.AllowedOrigins)(handler)
 	handler = h2c.NewHandler(handler, &http2.Server{})
 
 	return handler, nil


### PR DESCRIPTION
CSRF 攻撃の対策として，Origin と Sec-Fetch-Site をチェックするミドルウェアを追加した。
既に認証用の Cookie は SameSite: Strict なものしかないのでそれで十分かもしれないが……

FYI: https://blog.jxck.io/entries/2024-04-26/csrf.html
