### PR TITLE
fix: 登録完了時にページ遷移しないことがあったのを修正

### DIFF
--- a/frontend/packages/contestant/app/features/viewer/signup.ts
+++ b/frontend/packages/contestant/app/features/viewer/signup.ts
@@ -16,24 +16,24 @@ export async function signUp(
   baseURL?: string,
 ): Promise<SignUpResponse> {
   const result: SignUpResponse = {};
-  let error = false;
   if (request.invitationCode === "") {
     result.invitationCodeError = "required";
-    error = true;
+    result.error = "invalid";
   }
   if (request.name === "") {
     result.nameError = "required";
-    error = true;
+    result.error = "invalid";
   }
   if (request.displayName === "") {
     result.displayNameError = "required";
-    error = true;
+    result.error = "invalid";
   }
-  if (error) {
+  if (result.error != null) {
     return result;
   }
 
   const url = new URL(baseURL ?? window.location.href);
+  url.search = "";
   url.pathname = "/api/auth/signup";
   const resp = await fetch(url, {
     method: "POST",


### PR DESCRIPTION
/signup で登録した後に / に遷移しないことがあった．

登録フォームの完了後に`router.invalidate`を呼んでリロードし，その結果をもとに遷移するようにした．
より通常のフォームに近い実装ではあるが，若干ピタゴラスイッチ的ではある……

