### PR TITLE
CI で go clean -modcache が走る閾値を大きくした

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -22,7 +22,8 @@ runs:
         && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
       run: |
         CACHE_SIZE=$(du -sm ~/go/pkg/mod 2>/dev/null | cut -f1 || echo "0")
-        if [ "$CACHE_SIZE" -gt 200 ]; then
+        if [ "$CACHE_SIZE" -gt 300 ]; then
+          echo "Clean Go Mod Cache"
           go clean -modcache
         fi
       shell: bash


### PR DESCRIPTION
しばらく動かしてみたら 246MB くらいあったので閾値を余裕を持って 300MB くらいにしておく
