### PR TITLE
fix: navbar transitioning on /problems/$code

### DIFF
--- a/frontend/packages/contestant/app/components/app-shell/index.ts
+++ b/frontend/packages/contestant/app/components/app-shell/index.ts
@@ -1,4 +1,4 @@
-export { Layout } from "./layout";
+export { NavbarLayoutContext, Layout } from "./layout";
 export { Header } from "./header";
 export { Navbar } from "./navbar";
 export { AccountMenu } from "./account-menu";

--- a/frontend/packages/contestant/app/components/app-shell/layout.tsx
+++ b/frontend/packages/contestant/app/components/app-shell/layout.tsx
@@ -1,5 +1,11 @@
-import { type ReactNode } from "react";
+import { createContext, useState, type ReactNode } from "react";
 import { clsx } from "clsx";
+
+export const NavbarLayoutContext = createContext<{
+  navbarTransitioning: boolean;
+}>({
+  navbarTransitioning: false,
+});
 
 export function Layout({
   children,
@@ -13,26 +19,35 @@ export function Layout({
   readonly navbarCollapsed: boolean;
 }) {
   const navbarEnabled = navbar != null;
+  const [navbarTransitioning, setNavbarTransitioning] = useState(false);
   return (
-    <div
-      className={clsx(
-        "grid h-screen w-screen grid-rows-[70px_1fr] duration-75 [--content-height:calc(100vh-70px)] [--header-height:70px] motion-safe:transition-[grid-template-columns]",
-        navbarEnabled
-          ? navbarCollapsed
-            ? "grid-cols-[50px_1fr] [--content-width:calc(100vw-50px)]"
-            : "grid-cols-[220px_1fr] [--content-width:calc(100vw-220px)]"
-          : "grid-cols-[0_1fr] [--content-width:100vw]",
-      )}
-    >
-      <header className="sticky top-0 col-span-full row-start-1 row-end-2">
-        {header}
-      </header>
-      <nav className="sticky top-[--header-height] col-start-1 col-end-2 row-start-2 row-end-3 h-[--content-height]">
-        {navbar}
-      </nav>
-      <main className="col-start-2 col-end-3 row-start-2 row-end-3 overflow-y-auto overflow-x-clip">
-        {children}
-      </main>
-    </div>
+    <NavbarLayoutContext value={{ navbarTransitioning }}>
+      <div
+        className={clsx(
+          "grid h-screen w-screen grid-rows-[70px_1fr] duration-75 [--content-height:calc(100vh-70px)] [--header-height:70px] motion-safe:transition-[grid-template-columns]",
+          !navbarEnabled && "grid-cols-[0_1fr] [--content-width:100vw]",
+          navbarEnabled && [
+            navbarCollapsed &&
+              "grid-cols-[50px_1fr] [--content-width:calc(100vw-50px)]",
+            !navbarCollapsed &&
+              "grid-cols-[220px_1fr] [--content-width:calc(100vw-220px)]",
+          ],
+        )}
+        // React19 からサポートされる
+        // eslint-disable-next-line react/no-unknown-property
+        onTransitionStart={() => setNavbarTransitioning(true)}
+        onTransitionEnd={() => setNavbarTransitioning(false)}
+      >
+        <header className="sticky top-0 col-span-full row-start-1 row-end-2">
+          {header}
+        </header>
+        <nav className="sticky top-[--header-height] col-start-1 col-end-2 row-start-2 row-end-3 h-[--content-height]">
+          {navbar}
+        </nav>
+        <main className="col-start-2 col-end-3 row-start-2 row-end-3 overflow-y-auto overflow-x-clip">
+          {children}
+        </main>
+      </div>
+    </NavbarLayoutContext>
   );
 }

--- a/frontend/packages/contestant/app/routes/~problems.$code/page.tsx
+++ b/frontend/packages/contestant/app/routes/~problems.$code/page.tsx
@@ -14,6 +14,7 @@ import {
 import { clsx } from "clsx";
 import { MaterialSymbol } from "@app/components/material-symbol";
 import { Markdown, Typography } from "@app/components/markdown";
+import { NavbarLayoutContext } from "@app/components/app-shell";
 
 export function ProblemPage(props: { problem: Promise<ProblemDetail> }) {
   const problem = use(props.problem);
@@ -25,6 +26,7 @@ export function Layout(props: {
   content: React.ReactNode;
   sidebar: React.ReactNode;
 }) {
+  const { navbarTransitioning } = use(NavbarLayoutContext);
   const [showSidebar, toggleSidebar] = useReducer((o) => !o, false);
 
   return (
@@ -38,6 +40,7 @@ export function Layout(props: {
         className={clsx(
           "overflow-y-auto px-40 pb-64",
           "w-[--span] lg:w-[calc(var(--span)*2)]",
+          navbarTransitioning && "transition-[width]",
         )}
       >
         {props.content}
@@ -49,6 +52,7 @@ export function Layout(props: {
           !showSidebar &&
             "translate-x-[calc(var(--span)-64px)] sm:translate-x-0",
           "sm:w-[--span] sm:pl-0",
+          navbarTransitioning && "transition-[width]",
         )}
       >
         <Button


### PR DESCRIPTION
左側のナビゲーションバーを開閉する際にレイアウトが変化するトランジションが発生する．
内容が grid や flex による現在のボックスサイズを参照する制御になっている場合は正しくトランジションが行われるが，
問題詳細ページは width によって手動で制御されているためトランジションされずにレイアウトが崩れていた．
トランジションの状態を Context により伝達し，width で大きさを制御しているコンポーネントに開閉中のみ width をトランジションさせるように伝えることで正しいレイアウトが反映されるようにした．
