### PR TITLE
feat: Markdown の表示を改善

### DIFF
--- a/frontend/packages/config/eslint/config.js
+++ b/frontend/packages/config/eslint/config.js
@@ -132,6 +132,15 @@ function config(opts = {}) {
           "import/default": "off",
           "import/no-named-as-default-member": "off",
           "import/no-unresolved": "off",
+          "no-unused-vars": "off",
+          "@typescript-eslint/no-unused-vars": [
+            "error",
+            {
+              ignoreRestSiblings: true,
+              argsIgnorePattern: "^_",
+              caughtErrors: "all",
+            },
+          ],
         },
       },
     ]),

--- a/frontend/packages/contestant/app/components/markdown/markdown.module.css
+++ b/frontend/packages/contestant/app/components/markdown/markdown.module.css
@@ -44,7 +44,7 @@
   }
   ul,
   ol {
-    @apply pl-24;
+    margin-left: 1em;
   }
 
   hr {
@@ -66,5 +66,17 @@
 
   tr:nth-child(even) {
     @apply bg-surface-1/50;
+  }
+
+  blockquote {
+    @apply border-l-4 border-primary bg-surface-1/50 pl-8;
+  }
+
+  :where(code):not(pre > code) {
+    @apply rounded-4 bg-surface-1 px-4 py-2 font-mono text-14;
+  }
+
+  pre:has(> code) {
+    @apply block overflow-x-auto rounded-4 bg-surface-1/50 py-2 font-mono text-14;
   }
 }

--- a/frontend/packages/contestant/app/components/markdown/markdown.tsx
+++ b/frontend/packages/contestant/app/components/markdown/markdown.tsx
@@ -1,9 +1,9 @@
 import { clsx } from "clsx";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
-import "katex/dist/katex.min.css";
+import katexCSS from "katex/dist/katex.min.css?url";
 import styles from "./markdown.module.css";
 
 export function Typography(props: {
@@ -19,10 +19,30 @@ export function Typography(props: {
 
 const remarkPlugins = [remarkGfm, remarkMath];
 const rehypePlugins = [rehypeKatex];
+const markdownComponents: Components = {
+  span: (props) => {
+    const { node: _node, ...elProps } = props;
+    const el = <span {...elProps} />;
+
+    if (elProps.className?.includes("katex")) {
+      return (
+        <>
+          <link rel="stylesheet" precedence="low" href={katexCSS} />
+          {el}
+        </>
+      );
+    }
+    return el;
+  },
+};
 
 export function Markdown({ children }: { children?: string }) {
   return (
-    <ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
+    <ReactMarkdown
+      remarkPlugins={remarkPlugins}
+      rehypePlugins={rehypePlugins}
+      components={markdownComponents}
+    >
       {children}
     </ReactMarkdown>
   );


### PR DESCRIPTION
コード系の表示をサポートした(ブロックコードのシンタックスハイライトは未対応)．引用表示もサポートした．
数式が表示されない場合に KaTeX のスタイルが読まれないようにした(KaTeX 自体は依然としてロードされる)
