### PR TITLE
fix: remove extensions not included in postgres image

### DIFF
--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,6 +1,4 @@
 CREATE EXTENSION pg_stat_statements;
-CREATE EXTENSION pg_stat_kcache;
-CREATE EXTENSION set_user;
 CREATE EXTENSION btree_gist;
 
 CREATE TABLE rules (


### PR DESCRIPTION
本当はこれらの拡張が既に入っているイメージを開発用に使うべきかもしれない