### PR TITLE
feat(problem): add redeployable state

### DIFF
--- a/backend/scoreserver/contestant/problem.go
+++ b/backend/scoreserver/contestant/problem.go
@@ -58,9 +58,12 @@ func (h *ProblemServiceHandler) ListProblems(
 	protoProblems := make([]*contestantv1.Problem, 0, len(problems))
 	for _, problem := range problems {
 		protoProblems = append(protoProblems, &contestantv1.Problem{
-			Code:     string(problem.Problem().Code()),
-			Title:    problem.Problem().Title(),
-			MaxScore: problem.Problem().MaxScore(),
+			Code:     string(problem.Code()),
+			Title:    problem.Title(),
+			MaxScore: problem.MaxScore(),
+			Deployment: &contestantv1.Deployment{
+				Redeployable: problem.Redeployable(),
+			},
 		})
 	}
 
@@ -103,6 +106,9 @@ func (h *ProblemServiceHandler) GetProblem(
 		Code:     string(detail.Code()),
 		Title:    detail.Title(),
 		MaxScore: detail.MaxScore(),
+		Deployment: &contestantv1.Deployment{
+			Redeployable: detail.Redeployable(),
+		},
 		Body: &contestantv1.ProblemBody{
 			Type: contestantv1.ProblemType_PROBLEM_TYPE_DESCRIPTIVE,
 			Body: &contestantv1.ProblemBody_Descriptive{

--- a/backend/scoreserver/domain/problem.go
+++ b/backend/scoreserver/domain/problem.go
@@ -135,6 +135,10 @@ func (p *Problem) RedeployRule() RedeployRule {
 	return p.redeployRule
 }
 
+func (p *Problem) Redeployable() bool {
+	return p.redeployRule != RedeployRuleUnredeployable
+}
+
 func (p *Problem) PercentagePenalty() *RedeployPenaltyPercentage {
 	if p.redeployRule != RedeployRulePercentagePenalty {
 		return nil

--- a/backend/scoreserver/domain/team_problem.go
+++ b/backend/scoreserver/domain/team_problem.go
@@ -4,8 +4,8 @@ import "context"
 
 type (
 	TeamProblem struct {
-		team    *Team
-		problem *Problem
+		*problem
+		team *Team
 	}
 	TeamProblemDetail struct {
 		team          *Team

--- a/frontend/packages/contestant/app/features/problem/index.ts
+++ b/frontend/packages/contestant/app/features/problem/index.ts
@@ -21,6 +21,7 @@ export async function fetchProblems(transport: Transport): Promise<Problem[]> {
 export type ProblemDetail = {
   code: string;
   title: string;
+  redeployable: boolean;
   body: string;
 };
 
@@ -40,6 +41,7 @@ export async function fetchProblem(
   return {
     code: problem.code,
     title: problem.title,
+    redeployable: problem.deployment?.redeployable ?? false,
     body,
   };
 }


### PR DESCRIPTION
再展開可能か?という状態である`Redeployable`を定義し，競技者 API から参照できるようにした