### PR TITLE
feat: Add a spoiler for showing answers without rendering them as Markdown documents

### DIFF
--- a/frontend/packages/admin/app/routes/~submissions.$problem.$team.$id/~route.tsx
+++ b/frontend/packages/admin/app/routes/~submissions.$problem.$team.$id/~route.tsx
@@ -98,6 +98,7 @@ function RouteComponent() {
   const deferredMarkingResults = useDeferredValue(markingResultsPromise);
   const problem = use(deferredProblemPromise);
   const answer = use(deferredAnswerPromise);
+  const answerString = answer?.body?.body.value?.body ?? "";
   const markingResults = use(deferredMarkingResults);
 
   const router = useRouter();
@@ -123,7 +124,13 @@ function RouteComponent() {
       <Grid.Col span={10}>
         <article>
           <Title>解答</Title>
-          <Markdown>{answer?.body?.body.value?.body ?? ""}</Markdown>
+          <Markdown>{answerString}</Markdown>
+        </article>
+        <article>
+          <details>
+            <summary>プレーンテキスト版</summary>
+            <pre>{answerString}</pre>
+          </details>
         </article>
         <article>
           <Title>問題解説</Title>


### PR DESCRIPTION
## 概要

提出された解答を Markdown レンダラを介さずに単に pre タグで囲んだものが閲覧できるようにします。

## スクリーンショット

<img width="676" alt="Screenshot 2025-03-15 at 21 00 59" src="https://github.com/user-attachments/assets/3b08a42e-6bc4-4e52-beaa-9f3dc05727cf" />

<img width="717" alt="Screenshot 2025-03-15 at 21 00 48" src="https://github.com/user-attachments/assets/d6e83738-79db-46ba-8544-a5d9324f2f36" />
