### PR TITLE
chore(renovate): limit concurrent PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,7 @@
     "config:recommended"
   ],
   "prHourlyLimit": 0,
-  "prConcurrentLimit": 0,
+  "prConcurrentLimit": 20,
   "platformAutomerge": true,
   "labels": [
     "dependencies"


### PR DESCRIPTION
PR が多すぎると Actions のキューが詰まって進行しなくなるので