### PR TITLE
docs: Add CLAUDE.md configuration files for backend and frontend

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Building
+- **Run scoreserver**: `./scripts/local-exec go run ./cmd/scoreserver/ -dev` (starts with local DB/Redis)
+- **Build binary**: `go build ./cmd/scoreserver/`
+
+### Testing
+- **Run all tests**: `go test ./...`
+- **Run single test**: `go test -run TestName ./path/to/package`
+- Tests use Testcontainers for isolated environment
+
+### Linting
+- **Lint check**: `golangci-lint run`
+- Configuration: `.golangci.yaml`
+
+### Database
+- **Access local DB**: `./scripts/local-exec psql`
+- **Run migrations**: `./scripts/local-exec ./scripts/migrate`
+- **Access K8s DB**: `./scripts/kube-exec psql`
+
+### Dependencies
+- **Start local services**: `docker compose up -d` (PostgreSQL, Redis, Jaeger)
+
+### Code Generation
+- **Generate code**: `go generate ./...` (runs buf for protobuf generation)
+
+## Architecture Overview
+
+This is a Go backend for a CTF scoring server using Connect RPC (gRPC-Web compatible).
+
+### Core Structure
+- **cmd/**: Entry points
+  - `scoreserver/`: Main scoring server
+  - `batch/`: Batch processing tools
+  - `create-team/`: Team creation utility
+  - `retrieve-token/`: Token retrieval utility
+
+- **scoreserver/**: Main application logic
+  - `domain/`: Core business entities (User, Team, Problem, Answer, Score, etc.)
+  - `admin/`: Admin API handlers (Connect RPC)
+  - `contestant/`: Contestant API handlers (Connect RPC)
+  - `infra/`: Infrastructure implementations
+    - `pg/`: PostgreSQL repositories
+    - `discord/`: Discord OAuth integration
+    - `sstate/`: Redis session state
+  - `config/`: Configuration management
+  - `batch/`: Batch job implementations
+
+- **pkg/proto/**: Generated protobuf/Connect code
+  - `admin/`: Admin API definitions
+  - `contestant/`: Contestant API definitions
+
+### Key Design Patterns
+- **Repository Pattern**: Domain models have corresponding repositories in `infra/pg/`
+- **Connect RPC**: API uses Connect protocol (gRPC-Web compatible) with protobuf
+- **Session Management**: Redis-based sessions via `sstate` package
+- **Transactions**: Uses `domain.Tx` interface for database transactions
+- **Testing**: Tests use Testcontainers for isolated PostgreSQL instances
+
+### Authentication & Authorization
+- Discord OAuth2 for user authentication
+- Session-based auth using Redis
+- Admin/Contestant role separation via different endpoints
+
+### Key Technologies
+- **API**: Connect RPC (protobuf-based)
+- **Database**: PostgreSQL with pgx driver
+- **Session Store**: Redis
+- **Observability**: OpenTelemetry (traces via Jaeger)
+- **Testing**: Testcontainers for integration tests

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Development Commands
 
 ### Building
-- **Run scoreserver**: `./scripts/local-exec go run ./cmd/scoreserver/ -dev` (starts with local DB/Redis)
+- **Run scoreserver**: `./scripts/local-exec go run ./cmd/scoreserver/ -dev -contestant.base-url=http://localhost:3000/api -fake.schedule` (starts with local DB/Redis)
 - **Build binary**: `go build ./cmd/scoreserver/`
 
 ### Testing
@@ -15,6 +15,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Linting
 - **Lint check**: `golangci-lint run`
+- **Format code**: `golangci-lint fmt`
 - Configuration: `.golangci.yaml`
 
 ### Database
@@ -30,7 +31,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Architecture Overview
 
-This is a Go backend for a CTF scoring server using Connect RPC (gRPC-Web compatible).
+This is a Go backend for a ICTSC scoring server using Connect RPC (gRPC-Web compatible).
 
 ### Core Structure
 - **cmd/**: Entry points
@@ -46,7 +47,7 @@ This is a Go backend for a CTF scoring server using Connect RPC (gRPC-Web compat
   - `infra/`: Infrastructure implementations
     - `pg/`: PostgreSQL repositories
     - `discord/`: Discord OAuth integration
-    - `sstate/`: Redis session state
+    - `sstate/`: Problem deployment state management
   - `config/`: Configuration management
   - `batch/`: Batch job implementations
 
@@ -57,7 +58,7 @@ This is a Go backend for a CTF scoring server using Connect RPC (gRPC-Web compat
 ### Key Design Patterns
 - **Repository Pattern**: Domain models have corresponding repositories in `infra/pg/`
 - **Connect RPC**: API uses Connect protocol (gRPC-Web compatible) with protobuf
-- **Session Management**: Redis-based sessions via `sstate` package
+- **Problem State Management**: Problem deployment state via `sstate` package
 - **Transactions**: Uses `domain.Tx` interface for database transactions
 - **Testing**: Tests use Testcontainers for isolated PostgreSQL instances
 
@@ -70,5 +71,5 @@ This is a Go backend for a CTF scoring server using Connect RPC (gRPC-Web compat
 - **API**: Connect RPC (protobuf-based)
 - **Database**: PostgreSQL with pgx driver
 - **Session Store**: Redis
-- **Observability**: OpenTelemetry (traces via Jaeger)
+- **Observability**: OpenTelemetry (traces)
 - **Testing**: Testcontainers for integration tests

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Monorepo Management
+- **Install dependencies**: `pnpm install`
+- **Build all packages**: `pnpm build`
+- **Run all tests**: `pnpm ci:test`
+- **Run all lints**: `pnpm ci:lint`
+- **Generate protobuf code**: `pnpm generate`
+
+### Contestant Dashboard (main app)
+Run from `packages/contestant/`:
+- **Development server**: `pnpm dev` (runs on localhost:3000, proxies API calls to localhost:8080)
+- **Build**: `pnpm build`
+- **Test**: `pnpm test` (uses Vitest)
+- **Lint check**: `pnpm lint` (runs TypeScript, ESLint, and Prettier checks in parallel)
+- **Fix linting**: `pnpm lint-fix`
+- **Storybook**: `pnpm story` (runs on localhost:6006)
+- **Build Storybook**: `pnpm story:build`
+
+### Admin Dashboard
+Run from `packages/admin/`:
+- **Development server**: `pnpm dev`
+- **Build**: `pnpm build`
+- **Lint check**: `pnpm lint` (TypeScript, ESLint, Prettier)
+- **Fix linting**: `pnpm lint-fix`
+
+### Proto Package
+Run from `packages/proto/`:
+- **Generate protobuf code**: `pnpm generate` (runs buf generate and creates exports)
+
+## Architecture Overview
+
+This is a React frontend monorepo for the ICTSC CTF platform using pnpm workspaces.
+
+### Package Structure
+- **packages/contestant/**: Competition participant dashboard
+  - `app/components/`: Reusable UI components without business logic
+  - `app/features/`: Business logic, API calls, and state management
+  - `app/routes/`: Page definitions using TanStack Router (file-based routing)
+  - `assets/`: Static assets
+  - Uses Tailwind CSS for styling
+
+- **packages/admin/**: Administration dashboard
+  - Uses Mantine UI components
+  - Similar architecture to contestant app
+
+- **packages/proto/**: Generated protobuf/Connect RPC code
+  - Exports: `@ictsc/proto/admin/v1` and `@ictsc/proto/contestant/v1`
+  - Generated from proto files in backend repository
+
+- **packages/config/**: Shared configuration
+  - ESLint config: `@ictsc/config/eslint`
+  - Prettier config: `@ictsc/config/prettier`
+
+### Key Technologies
+- **Framework**: React 19 with TypeScript
+- **Routing**: TanStack Router with file-based routing (prefix `~` for route files)
+- **API Communication**: Connect RPC (gRPC-Web compatible)
+- **Styling**:
+  - Contestant: Tailwind CSS
+  - Admin: Mantine UI
+- **Build Tool**: Vite
+- **Testing**: Vitest
+- **Component Development**: Storybook (contestant app only)
+- **Code Quality**: ESLint, Prettier, TypeScript strict mode
+
+### Development Patterns
+- **File-based routing**: Routes are auto-generated from files in `app/routes/` prefixed with `~`
+- **API proxy**: Development server proxies `/api` requests to backend at `localhost:8080`
+- **Shared proto types**: Both apps use `@ictsc/proto` for type-safe API communication
+- **Monorepo commands**: Root commands run recursively on all packages with `--recursive --parallel`
+
+### Backend Integration
+- Backend runs on `localhost:8080` (see `../backend/CLAUDE.md` for backend details)
+- Uses Connect RPC protocol for API communication
+- Authentication via Discord OAuth2 with session management

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -34,7 +34,7 @@ Run from `packages/proto/`:
 
 ## Architecture Overview
 
-This is a React frontend monorepo for the ICTSC CTF platform using pnpm workspaces.
+This is a React frontend monorepo for the ICTSC platform using pnpm workspaces.
 
 ### Package Structure
 - **packages/contestant/**: Competition participant dashboard


### PR DESCRIPTION
指示通りバックエンドとフロントエンドのそれぞれにおいて Opus を使って `/init ultrathink` しました。
生成結果そのままであり、一切人の手を入れていません。

🤖 Generated with [Claude Code](https://claude.ai/code)