### PR TITLE
feat: reduce answer interval to 1ms

### DIFF
--- a/backend/scoreserver/domain/answer.go
+++ b/backend/scoreserver/domain/answer.go
@@ -36,7 +36,7 @@ type (
 )
 
 const (
-	AnswerInterval = 20 * time.Minute
+	AnswerInterval = 1 * time.Millisecond
 )
 
 func ListAnswersForAdmin(ctx context.Context, eff AnswerReader) ([]*Answer, error) {

--- a/backend/scoreserver/domain/answer_test.go
+++ b/backend/scoreserver/domain/answer_test.go
@@ -43,7 +43,7 @@ func TestSubmitDescriptiveAnswer(t *testing.T) {
 					Problem:   domain.FixDescriptiveProblem1(t, nil).Problem().Data(),
 					Author:    domain.FixUser1(t, nil).Data(),
 					CreatedAt: time.Date(2021, 1, 1, 1, 0, 0, 0, time.UTC),
-					Interval:  20 * time.Minute,
+					Interval:  1 * time.Millisecond,
 				},
 				Body: &domain.AnswerBodyData{
 					Descriptive: &domain.DescriptiveAnswerBodyData{
@@ -80,7 +80,7 @@ func TestSubmitDescriptiveAnswer(t *testing.T) {
 					Problem:   domain.FixDescriptiveProblem1(t, nil).Problem().Data(),
 					Author:    domain.FixUser1(t, nil).Data(),
 					CreatedAt: time.Date(2021, 1, 1, 1, 30, 0, 0, time.UTC),
-					Interval:  20 * time.Minute,
+					Interval:  1 * time.Millisecond,
 				},
 				Body: &domain.AnswerBodyData{
 					Descriptive: &domain.DescriptiveAnswerBodyData{


### PR DESCRIPTION
Resolves #2015

再送信までの間隔を 1 ミリ秒までに短縮します。

### 実装の方針

設定可能な形にするのは変更箇所が多いので、ハードコードしたまま再送信間隔を短くすることで最低限の変更だけで実現しています。

1 ミリ秒の代わりに完全な 0 にすると `answers` テーブルの `created_at_range` カラムの値が `empty` となります。
`empty` の際に ListAnswers の処理でエラーが発生するため、 0 にはせずに 1 ミリ秒だけ間隔を残す形にしています。

### 動作確認

ローカルでバックエンドとフロントエンドを動かし、ブラウザから contestant として解答を送信した直後でも解答を再送信できることを確認しました。また、送信直後においても「解答可能まで」の残り時間表示が実施されないことを確認しました。