### PR TITLE
Update Debian to 13

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -54,7 +54,7 @@ chmod +x /usr/local/bin/psqldef
 EOS
 # Add a user
 ARG UID=1000
-RUN adduser --uid ${UID} --disabled-password --gecos '' toolbox
+RUN useradd -u "${UID}" -m -s /bin/bash -c "" -p "!" toolbox
 USER toolbox
 # Copy scripts
 WORKDIR /home/toolbox

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -35,7 +35,7 @@ COPY --from=batch-builder --chown=nonroot:nonroot /batch /
 ENTRYPOINT ["/batch"]
 
 # -- toolbox ---
-FROM debian:12-slim AS toolbox
+FROM debian:13-slim AS toolbox
 # Install tools
 RUN --mount=type=cache,target=/var/lib/apt/ \
     --mount=type=cache,target=/var/cache/apt/ \


### PR DESCRIPTION
#2087 で Renovate が上げようとしていますが、 CI が落ちているので修正します。

```
------
 > [toolbox toolbox 4/7] RUN adduser --uid 1000 --disabled-password --gecos '' toolbox:
0.102 /bin/sh: 1: adduser: not found
------
WARNING: No output specified for batch, toolbox, frontend, backend target(s) with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
Dockerfile:57
--------------------
  55 |     # Add a user
  56 |     ARG UID=1000
  57 | >>> RUN adduser --uid ${UID} --disabled-password --gecos '' toolbox
  58 |     USER toolbox
  59 |     # Copy scripts
--------------------
ERROR: target toolbox: failed to solve: process "/bin/sh -c adduser --uid ${UID} --disabled-password --gecos '' toolbox" did not complete successfully: exit code: 127
```