### PR TITLE
Gate deployment endpoints by per-problem submission schedules

### DIFF
--- a/backend/scoreserver/contestant/problem.go
+++ b/backend/scoreserver/contestant/problem.go
@@ -252,9 +252,7 @@ func (h *ProblemServiceHandler) ListDeployments(
 		}
 		return nil, err
 	}
-	if err := enforceDeploymentWindow(ctx, time.Now(), h.ListDeploymentsEffect); err != nil {
-		return nil, err
-	}
+	now := time.Now()
 
 	protoCode := req.Msg.GetCode()
 	if protoCode == "" {
@@ -273,6 +271,9 @@ func (h *ProblemServiceHandler) ListDeployments(
 
 	teamProblem, err := teamMember.Team().ProblemByCodeForPublic(ctx, h.ListDeploymentsEffect, code)
 	if err != nil {
+		return nil, err
+	}
+	if err := enforceDeploymentWindow(ctx, now, h.ListDeploymentsEffect, teamProblem.Problem()); err != nil {
 		return nil, err
 	}
 
@@ -310,9 +311,6 @@ func (h *ProblemServiceHandler) Deploy(
 		return nil, err
 	}
 	now := time.Now()
-	if err := enforceDeploymentWindow(ctx, now, h.DeployEffect); err != nil {
-		return nil, err
-	}
 
 	protoCode := req.Msg.GetCode()
 	if protoCode == "" {
@@ -333,6 +331,9 @@ func (h *ProblemServiceHandler) Deploy(
 	if err != nil {
 		return nil, err
 	}
+	if err := enforceDeploymentWindow(ctx, now, h.DeployEffect, teamProblem.Problem()); err != nil {
+		return nil, err
+	}
 
 	deployment, err := domain.RunTx(ctx, h.DeployEffect,
 		func(eff domain.DeploymentWriter) (*domain.Deployment, error) {
@@ -348,12 +349,21 @@ func (h *ProblemServiceHandler) Deploy(
 	}), nil
 }
 
-func enforceDeploymentWindow(ctx context.Context, now time.Time, scheduleReader domain.ScheduleReader) error {
-	schedule, err := domain.GetSchedule(ctx, scheduleReader)
+func enforceDeploymentWindow(
+	ctx context.Context,
+	now time.Time,
+	scheduleReader domain.ScheduleReader,
+	problem *domain.Problem,
+) error {
+	if problem == nil {
+		return connect.NewError(connect.CodeFailedPrecondition, errors.New("現在はデプロイできません"))
+	}
+
+	isSubmittable, err := problem.IsSubmittableAt(ctx, now, scheduleReader)
 	if err != nil {
 		return err
 	}
-	if schedule.Current(now) != nil {
+	if isSubmittable {
 		return nil
 	}
 	return connect.NewError(connect.CodeFailedPrecondition, errors.New("現在はデプロイできません"))

--- a/backend/scoreserver/contestant/problem_test.go
+++ b/backend/scoreserver/contestant/problem_test.go
@@ -43,8 +43,8 @@ func TestProblemServiceListDeploymentsRequiresActiveSchedule(t *testing.T) {
 			if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
 				t.Fatalf("connect.CodeOf(err) = %v, want %v (err=%v)", got, connect.CodeFailedPrecondition, err)
 			}
-			if store.getProblemByCodeCalls != 0 {
-				t.Fatalf("GetProblemByCode called %d times, want 0", store.getProblemByCodeCalls)
+			if store.getProblemByCodeCalls == 0 {
+				t.Fatal("GetProblemByCode was not called")
 			}
 		})
 	}
@@ -66,6 +66,26 @@ func TestProblemServiceListDeploymentsWithinActiveSchedule(t *testing.T) {
 	}
 	if got := len(resp.Msg.GetDeployments()); got != 0 {
 		t.Fatalf("len(resp.Msg.Deployments) = %d, want 0", got)
+	}
+	if store.getProblemByCodeCalls == 0 {
+		t.Fatal("GetProblemByCode was not called")
+	}
+}
+
+func TestProblemServiceListDeploymentsRequiresProblemSchedule(t *testing.T) {
+	t.Parallel()
+
+	store := newProblemServiceTestStore([]*domain.ScheduleData{
+		testSchedule("other", time.Now().Add(-time.Hour), time.Now().Add(time.Hour)),
+		testSchedule("contest", time.Now().Add(time.Hour), time.Now().Add(2*time.Hour)),
+	})
+	client := newProblemServiceTestClient(t, store)
+
+	_, err := client.ListDeployments(t.Context(), connect.NewRequest(&contestantv1.ListDeploymentsRequest{
+		Code: "0001",
+	}))
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Fatalf("connect.CodeOf(err) = %v, want %v (err=%v)", got, connect.CodeFailedPrecondition, err)
 	}
 	if store.getProblemByCodeCalls == 0 {
 		t.Fatal("GetProblemByCode was not called")
@@ -97,6 +117,9 @@ func TestProblemServiceDeployRequiresActiveSchedule(t *testing.T) {
 			if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
 				t.Fatalf("connect.CodeOf(err) = %v, want %v (err=%v)", got, connect.CodeFailedPrecondition, err)
 			}
+			if store.getProblemByCodeCalls == 0 {
+				t.Fatal("GetProblemByCode was not called")
+			}
 			if store.createDeploymentCalls != 0 {
 				t.Fatalf("CreateDeployment called %d times, want 0", store.createDeploymentCalls)
 			}
@@ -126,7 +149,27 @@ func TestProblemServiceDeployWithinActiveSchedule(t *testing.T) {
 	}
 }
 
-func TestProblemServiceDeployChecksScheduleBeforeProblemValidation(t *testing.T) {
+func TestProblemServiceDeployRequiresProblemSchedule(t *testing.T) {
+	t.Parallel()
+
+	store := newProblemServiceTestStore([]*domain.ScheduleData{
+		testSchedule("other", time.Now().Add(-time.Hour), time.Now().Add(time.Hour)),
+		testSchedule("contest", time.Now().Add(time.Hour), time.Now().Add(2*time.Hour)),
+	})
+	client := newProblemServiceTestClient(t, store)
+
+	_, err := client.Deploy(t.Context(), connect.NewRequest(&contestantv1.DeployRequest{
+		Code: "0001",
+	}))
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Fatalf("connect.CodeOf(err) = %v, want %v (err=%v)", got, connect.CodeFailedPrecondition, err)
+	}
+	if store.createDeploymentCalls != 0 {
+		t.Fatalf("CreateDeployment called %d times, want 0", store.createDeploymentCalls)
+	}
+}
+
+func TestProblemServiceDeployValidatesCodeBeforeSchedule(t *testing.T) {
 	t.Parallel()
 
 	store := newProblemServiceTestStore([]*domain.ScheduleData{
@@ -137,8 +180,8 @@ func TestProblemServiceDeployChecksScheduleBeforeProblemValidation(t *testing.T)
 	_, err := client.Deploy(t.Context(), connect.NewRequest(&contestantv1.DeployRequest{
 		Code: "!",
 	}))
-	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
-		t.Fatalf("connect.CodeOf(err) = %v, want %v (err=%v)", got, connect.CodeFailedPrecondition, err)
+	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+		t.Fatalf("connect.CodeOf(err) = %v, want %v (err=%v)", got, connect.CodeInvalidArgument, err)
 	}
 	if store.getProblemByCodeCalls != 0 {
 		t.Fatalf("GetProblemByCode called %d times, want 0", store.getProblemByCodeCalls)


### PR DESCRIPTION
### Motivation

- Prevent teams from pre-deploying or inspecting deployments of problems that are not yet visible/submittable by enforcing per-problem schedules rather than any active global schedule.

### Description

- Updated `ListDeployments` and `Deploy` to load the requested problem first and then enforce deployment availability using that problem's `submissionable_schedules`.
- Refactored `enforceDeploymentWindow` to accept a `*domain.Problem` and to call `problem.IsSubmittableAt(...)` to decide allow/deny, returning `FailedPrecondition` when the problem is not currently submittable.
- Added tests `TestProblemServiceListDeploymentsRequiresProblemSchedule` and `TestProblemServiceDeployRequiresProblemSchedule`, and adjusted `TestProblemServiceDeployValidatesCodeBeforeSchedule` to assert invalid code validation happens before schedule gating.

### Testing

- Ran `go test ./scoreserver/contestant -run ProblemService -count=1` from the `backend/` directory and the test suite passed.
- Running `go test ./backend/scoreserver/contestant` from the repository root fails due to module root configuration (needs running from `backend/`), so tests were executed from the correct module directory and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b15011edd88326962c75d92fff010d)