### PR TITLE
Fix default fake schedule name for local seeded data

### DIFF
--- a/backend/cmd/scoreserver/option.go
+++ b/backend/cmd/scoreserver/option.go
@@ -54,7 +54,7 @@ func NewOption(fs *flag.FlagSet) *CLIOption {
 		"Route prefix for contestant API (e.g., '/api')")
 
 	fs.BoolVar(&opt.UseFakeSchedule, "fake.schedule", false, "Use fake schedule")
-	fs.StringVar(&opt.FakeScheduleName, "fake.schedule.name", "contest", "Fake schedule name (must match problem_schedules in DB)")
+	fs.StringVar(&opt.FakeScheduleName, "fake.schedule.name", "day1-pm", "Fake schedule name (must match problem_schedules in DB)")
 	fs.TextVar(&opt.FakeScheduleStartAt, "fake.schedule.start-at", time.Now(), "Fake schedule start time")
 	fs.TextVar(&opt.FakeScheduleEndAt, "fake.schedule.end-at", time.Now().Add(2*time.Hour), "Fake schedule end time")
 


### PR DESCRIPTION
### Motivation
- Local development seeds problem schedule names like `day1-am`/`day1-pm`, but the previous default fake schedule name `contest` did not match those names which resulted in empty problem lists and rejected submissions when `-fake.schedule` was used.

### Description
- Change the default `-fake.schedule.name` from `contest` to `day1-pm` in `backend/cmd/scoreserver/option.go` so the fake scheduler matches the seeded problem windows by default.

### Testing
- Attempted `go test ./backend/cmd/scoreserver` (failed due to missing module), then ran `go test ./cmd/scoreserver` and `timeout 60 go test -run TestDoesNotExist ./cmd/scoreserver`, which completed with no failing tests (`[no test files]`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b15031f750832694dd8be75ab28484)