### PR TITLE
feat: アクティビティタイムラインに円筒スクロール効果を追加

### DIFF
--- a/frontend/packages/contestant/app/routes/activity.page.tsx
+++ b/frontend/packages/contestant/app/routes/activity.page.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps } from "react";
+import { useEffect, useRef, type ComponentProps } from "react";
 import { clsx } from "clsx";
 import { Link } from "@tanstack/react-router";
 import { Title } from "../components/title";
@@ -24,6 +24,88 @@ const formatter = new Intl.DateTimeFormat("ja-JP", {
 });
 
 export function ActivityPage(props: ActivityPageProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const listEl = listRef.current;
+    if (!listEl) return;
+
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    // Find nearest scrollable ancestor
+    let scrollContainer: HTMLElement | null = listEl.parentElement;
+    while (scrollContainer) {
+      const style = getComputedStyle(scrollContainer);
+      if (
+        style.overflowY === "auto" ||
+        style.overflowY === "scroll" ||
+        style.overflow === "auto" ||
+        style.overflow === "scroll"
+      ) {
+        break;
+      }
+      scrollContainer = scrollContainer.parentElement;
+    }
+    const scrollTarget: HTMLElement | Window = scrollContainer ?? window;
+    const containerEl = scrollContainer ?? document.documentElement;
+
+    function update() {
+      if (!listEl) return;
+      const containerRect = containerEl.getBoundingClientRect();
+      const containerCenter = containerRect.top + containerEl.clientHeight / 2;
+      const halfHeight = containerEl.clientHeight / 2;
+
+      const rows = listEl.children;
+      for (let i = 0; i < rows.length; i++) {
+        const row = rows[i] as HTMLElement;
+        const rowRect = row.getBoundingClientRect();
+        const itemCenter = rowRect.top + row.offsetHeight / 2;
+        const distance = Math.abs(itemCenter - containerCenter);
+        const t = Math.min(distance / halfHeight, 1);
+        const scale = 1 - t * 0.5;
+        const opacity = 1 - t * 0.7;
+        // 縦線(child[0])はスキップし、時刻・矢印・カードだけにエフェクトを適用
+        for (let j = 1; j < row.children.length; j++) {
+          const child = row.children[j] as HTMLElement;
+          child.style.transform = `scale(${scale})`;
+          // opacity-50 クラス（未採点カード）の場合は元の 0.5 を掛け合わせる
+          const baseOpacity = child.classList.contains("opacity-50") ? 0.5 : 1;
+          child.style.opacity = `${opacity * baseOpacity}`;
+        }
+      }
+    }
+
+    function updatePadding() {
+      if (!listEl || listEl.children.length === 0) return;
+      const half = containerEl.clientHeight / 2;
+      const firstRow = listEl.children[0] as HTMLElement;
+      const lastRow = listEl.children[
+        listEl.children.length - 1
+      ] as HTMLElement;
+      listEl.style.paddingTop = `${Math.max(0, half - firstRow.offsetHeight / 2)}px`;
+      listEl.style.paddingBottom = `${Math.max(0, half - lastRow.offsetHeight / 2)}px`;
+    }
+
+    updatePadding();
+    update();
+
+    scrollTarget.addEventListener("scroll", update, { passive: true });
+    const observer = new ResizeObserver(() => {
+      updatePadding();
+      update();
+    });
+    observer.observe(containerEl);
+
+    return () => {
+      scrollTarget.removeEventListener("scroll", update);
+      observer.disconnect();
+      if (listEl) {
+        listEl.style.paddingTop = "";
+        listEl.style.paddingBottom = "";
+      }
+    };
+  }, [props.entries]);
+
   return (
     <>
       <Title>アクティビティ</Title>
@@ -31,7 +113,7 @@ export function ActivityPage(props: ActivityPageProps) {
         {props.entries.length === 0 ? (
           <p className="text-16 text-text mt-64">提出履歴がありません</p>
         ) : (
-          <div className="flex w-full max-w-screen-md flex-col">
+          <div ref={listRef} className="flex w-full max-w-screen-md flex-col">
             {props.entries.map((entry, index) => (
               <div
                 key={`${entry.problemCode}-${entry.answerId}`}


### PR DESCRIPTION
## Summary
- アクティビティページのタイムラインに円筒スクロール効果を追加
- ビューポート中央の行が最大サイズ(scale 1.0, opacity 1.0)で表示され、上下端に向かうほど縮小(0.5)+フェードアウト(0.3)
- DOM直接操作(style.transform / style.opacity)で60fps維持
- 縦線はエフェクト対象外にして接続を維持
- 未採点カードのグレーアウト(opacity-50)を保持
- 先頭/末尾カードがビューポート中央に来るようパディングを動的調整
- `prefers-reduced-motion: reduce` の場合はエフェクトをスキップ

## Test plan
- [x] ブラウザでアクティビティページをスクロールし、中央が最大・端が縮小+フェードすることを確認
- [x] 縦線が途切れずに接続されていることを確認
- [x] 未採点カード（採点中）がグレーアウトされていることを確認
- [x] 最初と最後のカードがスクロールでビューポート中央に到達できることを確認
- [x] `pnpm lint` でエラーがないこと

<img width="2535" height="1637" alt="image" src="https://github.com/user-attachments/assets/082c000a-e288-41f3-a6f4-a508fc1a0a97" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)