### PR TITLE
fix: グループソートで開始時刻が同じ場合に終了時刻でタイブレーク

### DIFF
--- a/frontend/packages/contestant/app/features/problem/group.ts
+++ b/frontend/packages/contestant/app/features/problem/group.ts
@@ -1,5 +1,6 @@
 import type { Problem, ScheduleEntry } from "@ictsc/proto/contestant/v1";
 import {
+  endAtMs,
   getTemporalStatus,
   startAtMs,
   type ScheduleTemporalStatus,
@@ -61,12 +62,14 @@ export function groupProblems(
       })),
       problems: problems.slice().sort((a, b) => a.code.localeCompare(b.code)),
       hasSubmittableProblem,
-      _sortKey: entries.length > 0 ? startAtMs(entries[0]) : Infinity,
+      _startKey: entries.length > 0 ? startAtMs(entries[0]) : Infinity,
+      _endKey:
+        entries.length > 0 ? endAtMs(entries[entries.length - 1]) : Infinity,
     }))
     .sort((a, b) => {
       if (a.hasSubmittableProblem !== b.hasSubmittableProblem) {
         return a.hasSubmittableProblem ? -1 : 1;
       }
-      return a._sortKey - b._sortKey;
+      return a._startKey - b._startKey || a._endKey - b._endKey;
     });
 }

--- a/frontend/packages/contestant/app/features/schedule/index.ts
+++ b/frontend/packages/contestant/app/features/schedule/index.ts
@@ -12,6 +12,7 @@ export { ScheduleProvider } from "./provider";
 export {
   getTemporalStatus,
   startAtMs,
+  endAtMs,
   type ScheduleTemporalStatus,
 } from "./temporal";
 export { useSchedule } from "./use-schedule";

--- a/frontend/packages/contestant/app/features/schedule/temporal.ts
+++ b/frontend/packages/contestant/app/features/schedule/temporal.ts
@@ -16,3 +16,7 @@ export function getTemporalStatus(
 export function startAtMs(entry: ScheduleEntry): number {
   return entry.startAt != null ? timestampDate(entry.startAt).getTime() : 0;
 }
+
+export function endAtMs(entry: ScheduleEntry): number {
+  return entry.endAt != null ? timestampDate(entry.endAt).getTime() : Infinity;
+}


### PR DESCRIPTION
## Summary
- 問題グループのソートで開始時刻が同じ場合に並び順が不定だったため、終了時刻が早いグループを先に表示するタイブレーカーを追加
- `endAtMs` ユーティリティ関数を `schedule/temporal.ts` に追加

## Changes
- `frontend/packages/contestant/app/features/schedule/temporal.ts` — `endAtMs` 関数を追加
- `frontend/packages/contestant/app/features/schedule/index.ts` — `endAtMs` を re-export
- `frontend/packages/contestant/app/features/problem/group.ts` — ソート条件に終了時刻のタイブレーカーを追加

## Test plan
- [x] TypeScript 型チェック (`tsc --noEmit`) が通ること
- [x] 開始時刻が同じグループが終了時刻順に並ぶことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)